### PR TITLE
fix(app): align httpClient with backend contracts

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -5,6 +5,7 @@ import {
   ApiAttendanceEvent,
   ApiAvailabilitySlot,
   ApiChatMessage,
+  ApiChatMessageList,
   ApiChatRoom,
   ApiCompany,
   ApiContract,
@@ -18,7 +19,7 @@ import {
 } from './types';
 import type { SubmitContractSignaturePayload } from './types';
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 async function getJson<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`);
@@ -130,9 +131,19 @@ export const httpClient = {
     return getJson<ApiChatRoom[]>('/chat/rooms');
   },
 
-  async getChatMessages(roomId: string, cursor?: string): Promise<ApiChatMessage[]> {
+  async getChatMessages(
+    roomId: string,
+    cursor?: string,
+  ): Promise<ApiChatMessageList> {
     const query = cursor ? `?cursor=${cursor}` : '';
-    return getJson<ApiChatMessage[]>(`/chat/rooms/${roomId}/messages${query}`);
+    const data = await getJson<{ items: ApiChatMessage[]; nextCursor?: string | null }>(
+      `/chat/rooms/${roomId}/messages${query}`,
+    );
+
+    return {
+      items: data.items,
+      nextCursor: data.nextCursor ?? null,
+    };
   },
 
   async sendChatMessage(roomId: string, text: string): Promise<ApiChatMessage> {
@@ -151,8 +162,7 @@ export const httpClient = {
   },
 
   async getUnreadCount(): Promise<number> {
-    const data = await getJson<{ count: number }>('/chat/unread-count');
-    return data.count;
+    const data = await getJson<{ unreadCount: number }>('/chat/unread-count');
+    return data.unreadCount;
   },
 };
-

--- a/src/api/mockClient.ts
+++ b/src/api/mockClient.ts
@@ -5,6 +5,7 @@ import {
   ApiAttendanceEvent,
   ApiAvailabilitySlot,
   ApiChatMessage,
+  ApiChatMessageList,
   ApiChatRoom,
   ApiCompany,
   ApiContract,
@@ -428,8 +429,11 @@ export const mockClient = {
     return MOCK_CHAT_ROOMS;
   },
 
-  async getChatMessages(roomId: string, _cursor?: string): Promise<ApiChatMessage[]> {
-    return MOCK_CHAT_MESSAGES.filter(m => m.roomId === roomId);
+  async getChatMessages(roomId: string, _cursor?: string): Promise<ApiChatMessageList> {
+    return {
+      items: MOCK_CHAT_MESSAGES.filter(m => m.roomId === roomId),
+      nextCursor: null,
+    };
   },
 
   async sendChatMessage(roomId: string, content: string): Promise<ApiChatMessage> {
@@ -464,4 +468,3 @@ export const mockClient = {
     return MOCK_CHAT_ROOMS.reduce((sum, r) => sum + r.unreadCount, 0);
   },
 };
-

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -213,3 +213,8 @@ export interface ApiChatMessage {
   // isMine은 앱에서 직접 계산: senderUserId === 현재 로그인 userId
   isMine: boolean;
 }
+
+export interface ApiChatMessageList {
+  items: ApiChatMessage[];
+  nextCursor: string | null;
+}

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -48,7 +48,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 for (const room of rooms) {
                     const msgs = await apiClient.getChatMessages(room.roomId);
                     if (!mounted) return;
-                    msgEntries[room.roomId] = msgs;
+                    msgEntries[room.roomId] = msgs.items;
                 }
                 setMessagesMap(msgEntries);
             } catch (e) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
     "paths": {


### PR DESCRIPTION
## Summary
- switch Expo TypeScript config to the packaged Expo base config
- align app chat API types with backend message list and unread count responses
- move the app API base URL to `EXPO_PUBLIC_API_URL`

## Notes
- kept lesson, attendance, and report routes aligned with the current backend controller (`/lesson-requests`, `/attendance-events`, `/lesson-reports`)
- updated mock client and chat context to match the same response shape

## Verification
- `npx tsc --noEmit`
- `npm run lint`

Closes #11