### PR TITLE
feat(auth): add instructor demo login

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -3,6 +3,7 @@
 
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
+import { Platform } from 'react-native';
 import {
   ApiAttendanceEvent,
   ApiAvailabilitySlot,
@@ -28,9 +29,34 @@ import {
   saveTokens,
 } from '../store/authStore';
 
-const extra = (Constants.expoConfig?.extra ?? {}) as { apiUrl?: string };
-const BASE_URL =
-  process.env.EXPO_PUBLIC_API_URL ?? extra.apiUrl ?? 'http://localhost:3000';
+const extra = (Constants.expoConfig?.extra ?? {}) as {
+  apiUrl?: string;
+  deviceApiUrl?: string;
+  useMockAuth?: boolean;
+};
+
+function normalizeAndroidLocalhost(url: string): string {
+  return url
+    .replace('://localhost', '://10.0.2.2')
+    .replace('://127.0.0.1', '://10.0.2.2');
+}
+
+function resolveBaseUrl(): string {
+  const configuredUrl =
+    process.env.EXPO_PUBLIC_API_URL ??
+    extra.deviceApiUrl ??
+    extra.apiUrl ??
+    'http://localhost:3000';
+
+  if (Platform.OS === 'android') {
+    return normalizeAndroidLocalhost(configuredUrl);
+  }
+
+  return configuredUrl;
+}
+
+const BASE_URL = resolveBaseUrl();
+const USE_MOCK_AUTH = extra.useMockAuth ?? true;
 
 type ApiError = Error & { code?: string; status?: number };
 type AuthFailureHandler = () => void | Promise<void>;
@@ -38,6 +64,12 @@ type AuthFailureHandler = () => void | Promise<void>;
 interface RefreshLoginResponse {
   accessToken: string;
   refreshToken: string;
+}
+
+interface DemoLoginPayload {
+  channel: 'web' | 'app';
+  email?: string;
+  userId?: string;
 }
 
 interface RequestOptions extends RequestInit {
@@ -186,7 +218,28 @@ function toLectureHistoryView(lessons: ApiLesson[], reports: ApiLessonReport[]):
 }
 
 export const httpClient = {
+  async loginWithDemoAccount(payload: DemoLoginPayload): Promise<AuthLoginResponse> {
+    return requestJson<AuthLoginResponse>('/auth/demo-login', {
+      method: 'POST',
+      requiresAuth: false,
+      retryOnUnauthorized: false,
+      body: JSON.stringify(payload),
+    });
+  },
+
   async loginWithGoogle(idToken: string): Promise<AuthLoginResponse> {
+    if (USE_MOCK_AUTH) {
+      return {
+        accessToken: `mock-access-token-${idToken.slice(0, 8)}`,
+        refreshToken: `mock-refresh-token-${idToken.slice(0, 8)}`,
+        user: {
+          userId: 'U1',
+          email: 'admin@example.com',
+          name: 'Demo Admin',
+        },
+      };
+    }
+
     return requestJson<AuthLoginResponse>('/auth/google', {
       method: 'POST',
       requiresAuth: false,

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,13 +1,9 @@
-import * as Crypto from 'expo-crypto';
-import * as WebBrowser from 'expo-web-browser';
-import * as Google from 'expo-auth-session/providers/google';
-import Constants from 'expo-constants';
 import { router } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -16,190 +12,187 @@ import {
 import { httpClient } from '@/src/api/httpClient';
 import { saveTokens } from '@/src/store/authStore';
 
-WebBrowser.maybeCompleteAuthSession();
-
-type AppExtra = {
-  googleClientId?: string;
-  googleAndroidClientId?: string;
-  googleIosClientId?: string;
-  googleWebClientId?: string;
+type DemoInstructor = {
+  email: string;
+  name: string;
+  description: string;
 };
 
-const extra = (Constants.expoConfig?.extra ?? {}) as AppExtra;
+const DEMO_INSTRUCTORS: DemoInstructor[] = [
+  {
+    email: 'teacher01@museum-demo.kr',
+    name: '김철수 강사',
+    description: '계약완료 수업 확인용',
+  },
+  {
+    email: 'teacher02@museum-demo.kr',
+    name: '이영희 강사',
+    description: '완료 수업 이력 확인용',
+  },
+  {
+    email: 'teacher03@museum-demo.kr',
+    name: '박지민 강사',
+    description: '배정 대기 요청 확인용',
+  },
+  {
+    email: 'teacher04@museum-demo.kr',
+    name: '정민수 강사',
+    description: '거절 이력 확인용',
+  },
+  {
+    email: 'teacher05@museum-demo.kr',
+    name: '강혜린 강사',
+    description: '진행중 수업 확인용',
+  },
+  {
+    email: 'teacher06@museum-demo.kr',
+    name: '김용관 강사',
+    description: '긴급 대강 후보 확인용',
+  },
+  {
+    email: 'teacher07@museum-demo.kr',
+    name: '박지혁 강사',
+    description: '완료 보고서 확인용',
+  },
+  {
+    email: 'teacher08@museum-demo.kr',
+    name: '최수빈 강사',
+    description: '신규 배정 대기 확인용',
+  },
+  {
+    email: 'teacher09@museum-demo.kr',
+    name: '오민재 강사',
+    description: '계약 발송 상태 확인용',
+  },
+  {
+    email: 'teacher10@museum-demo.kr',
+    name: '한지윤 강사',
+    description: '유물 탐구 수업 확인용',
+  },
+];
 
 export default function LoginScreen() {
-  const googleClientIds = {
-    androidClientId: extra.googleAndroidClientId ?? extra.googleClientId ?? '',
-    iosClientId: extra.googleIosClientId ?? extra.googleClientId ?? '',
-    webClientId: extra.googleWebClientId ?? extra.googleClientId ?? '',
-  };
-
-  const currentPlatformClientId =
-    Platform.select({
-      android: googleClientIds.androidClientId,
-      ios: googleClientIds.iosClientId,
-      web: googleClientIds.webClientId,
-      default: '',
-    }) ?? '';
-
-  if (!currentPlatformClientId) {
-    return <MockLoginCard />;
-  }
-
-  return <GoogleLoginCard googleClientIds={googleClientIds} />;
-}
-
-function MockLoginCard() {
+  const [selectedEmail, setSelectedEmail] = useState(DEMO_INSTRUCTORS[0].email);
+  const [isSelectorOpen, setIsSelectorOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const mockIdToken = useMemo(() => Crypto.randomUUID(), []);
+
+  const selectedInstructor = useMemo(
+    () =>
+      DEMO_INSTRUCTORS.find((instructor) => instructor.email === selectedEmail) ??
+      DEMO_INSTRUCTORS[0],
+    [selectedEmail],
+  );
 
   const completeLogin = async () => {
-    try {
-      setIsSubmitting(true);
-      setErrorMessage(null);
-
-      const data = await httpClient.loginWithGoogle(mockIdToken);
-      await saveTokens(data.accessToken, data.refreshToken);
-      router.replace('/(tabs)');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다.';
-      setErrorMessage(message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <LoginCard
-      buttonLabel="Google 계정으로 계속하기"
-      disabled={isSubmitting}
-      errorMessage={errorMessage}
-      helperText='Google client ID가 없어서 개발용 mock 로그인으로 동작합니다.'
-      isSubmitting={isSubmitting}
-      onPress={() => {
-        void completeLogin();
-      }}
-    />
-  );
-}
-
-function GoogleLoginCard({
-  googleClientIds,
-}: {
-  googleClientIds: {
-    androidClientId: string;
-    iosClientId: string;
-    webClientId: string;
-  };
-}) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    androidClientId: googleClientIds.androidClientId || undefined,
-    iosClientId: googleClientIds.iosClientId || undefined,
-    webClientId: googleClientIds.webClientId || undefined,
-    scopes: ['openid', 'profile', 'email'],
-  });
-
-  useEffect(() => {
-    if (response?.type !== 'success') {
-      return;
-    }
-
-    const idToken = response.params.id_token;
-    if (!idToken) {
-      setErrorMessage('Google ID 토큰을 가져오지 못했습니다.');
-      return;
-    }
-
-    void completeLogin(idToken);
-  }, [response]);
-
-  const completeLogin = async (idToken: string) => {
-    try {
-      setIsSubmitting(true);
-      setErrorMessage(null);
-
-      const data = await httpClient.loginWithGoogle(idToken);
-      await saveTokens(data.accessToken, data.refreshToken);
-      router.replace('/(tabs)');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다.';
-      setErrorMessage(message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleLoginPress = async () => {
     if (isSubmitting) {
       return;
     }
 
-    const result = await promptAsync();
-    if (result.type === 'dismiss') {
-      setErrorMessage('로그인이 취소되었습니다.');
+    try {
+      setIsSubmitting(true);
+      setErrorMessage(null);
+
+      const data = await httpClient.loginWithDemoAccount({
+        channel: 'app',
+        email: selectedInstructor.email,
+      });
+
+      await saveTokens(data.accessToken, data.refreshToken);
+      router.replace('/(tabs)');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다.';
+      setErrorMessage(message);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
-    <LoginCard
-      buttonLabel="Google 계정으로 계속하기"
-      disabled={isSubmitting || !request}
-      errorMessage={errorMessage}
-      isSubmitting={isSubmitting}
-      onPress={() => {
-        void handleLoginPress();
-      }}
-    />
-  );
-}
-
-function LoginCard({
-  buttonLabel,
-  disabled,
-  errorMessage,
-  helperText,
-  isSubmitting,
-  onPress,
-}: {
-  buttonLabel: string;
-  disabled: boolean;
-  errorMessage: string | null;
-  helperText?: string;
-  isSubmitting: boolean;
-  onPress: () => void;
-}) {
-  return (
     <View style={styles.container}>
       <View style={styles.card}>
         <Text style={styles.brand}>free-b</Text>
-        <Text style={styles.title}>강사 로그인</Text>
+        <Text style={styles.title}>발표용 데모 로그인</Text>
         <Text style={styles.description}>
-          구글 계정으로 로그인하고 수업, 계약, 채팅 데이터를 이어서 확인하세요.
+          강사 계정을 선택하면 데모 서버의 수업, 계약, 채팅 데이터를 바로 확인할 수
+          있습니다.
         </Text>
+
+        <Text style={styles.label}>강사 계정 선택</Text>
 
         <Pressable
           accessibilityRole="button"
-          disabled={disabled}
-          onPress={onPress}
+          disabled={isSubmitting}
+          onPress={() => {
+            setIsSelectorOpen((open) => !open);
+          }}
+          style={({ pressed }) => [
+            styles.selectorButton,
+            (pressed || isSelectorOpen) && styles.selectorButtonPressed,
+          ]}
+        >
+          <View style={styles.selectorHeader}>
+            <View style={styles.selectorCopy}>
+              <Text style={styles.selectorTitle}>{selectedInstructor.name}</Text>
+              <Text style={styles.selectorDescription}>
+                {selectedInstructor.description}
+              </Text>
+            </View>
+            <Text style={styles.selectorChevron}>{isSelectorOpen ? '▲' : '▼'}</Text>
+          </View>
+        </Pressable>
+
+        {isSelectorOpen ? (
+          <ScrollView style={styles.optionList} nestedScrollEnabled>
+            {DEMO_INSTRUCTORS.map((instructor) => {
+              const isSelected = instructor.email === selectedInstructor.email;
+
+              return (
+                <Pressable
+                  key={instructor.email}
+                  accessibilityRole="button"
+                  onPress={() => {
+                    setSelectedEmail(instructor.email);
+                    setIsSelectorOpen(false);
+                  }}
+                  style={({ pressed }) => [
+                    styles.optionRow,
+                    isSelected && styles.optionRowSelected,
+                    pressed && styles.optionRowPressed,
+                  ]}
+                >
+                  <Text style={styles.optionTitle}>{instructor.name}</Text>
+                  <Text style={styles.optionDescription}>
+                    {instructor.description}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        ) : null}
+
+        <Pressable
+          accessibilityRole="button"
+          disabled={isSubmitting}
+          onPress={() => {
+            void completeLogin();
+          }}
           style={({ pressed }) => [
             styles.button,
-            (pressed || isSubmitting || disabled) && styles.buttonPressed,
+            (pressed || isSubmitting) && styles.buttonPressed,
           ]}
         >
           {isSubmitting ? (
             <ActivityIndicator color="#fff" />
           ) : (
-            <Text style={styles.buttonText}>{buttonLabel}</Text>
+            <Text style={styles.buttonText}>선택한 강사로 로그인</Text>
           )}
         </Pressable>
 
-        {helperText ? <Text style={styles.helperText}>{helperText}</Text> : null}
+        <Text style={styles.helperText}>
+          백엔드 서버와 seed 데이터가 실행 중이어야 로그인됩니다.
+        </Text>
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
       </View>
     </View>
@@ -216,7 +209,7 @@ const styles = StyleSheet.create({
   },
   card: {
     width: '100%',
-    maxWidth: 360,
+    maxWidth: 380,
     padding: 24,
     borderRadius: 24,
     backgroundColor: '#fff',
@@ -243,6 +236,81 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#4b5563',
     marginBottom: 24,
+  },
+  label: {
+    marginBottom: 10,
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#374151',
+  },
+  selectorButton: {
+    minHeight: 68,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    backgroundColor: '#f9fafb',
+  },
+  selectorButtonPressed: {
+    borderColor: '#111827',
+    backgroundColor: '#f3f4f6',
+  },
+  selectorHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  selectorCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  selectorTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  selectorDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#6b7280',
+  },
+  selectorChevron: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  optionList: {
+    maxHeight: 220,
+    marginTop: 10,
+    marginBottom: 18,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  optionRow: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f3f4f6',
+    backgroundColor: '#fff',
+  },
+  optionRowSelected: {
+    backgroundColor: '#eff6ff',
+  },
+  optionRowPressed: {
+    opacity: 0.85,
+  },
+  optionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  optionDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#6b7280',
   },
   button: {
     minHeight: 52,


### PR DESCRIPTION
## Summary
- replace the app login screen with a demo instructor selector
- call `/auth/demo-login` for the selected instructor
- keep token storage and post-login routing intact

## Verification
- ./node_modules/.bin/eslint src/screens/LoginScreen.tsx src/api/httpClient.ts

Closes #33