### PR TITLE
feat(app): documents API 클라이언트 추가

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -432,6 +432,7 @@ export const httpClient = {
   },
 
   // --- Document Import APIs ---
+
   async uploadDocument(imageUri: string): Promise<ApiDocument> {
     const formData = new FormData();
     formData.append('file', {
@@ -455,11 +456,26 @@ export const httpClient = {
     return response.json();
   },
 
-  async extractDocument(documentId: string, text: string): Promise<ApiDocument> {
-    return postJson<ApiDocument>(`/documents/${documentId}/extract`, { text });
+  async getDocument(documentId: string): Promise<ApiDocument> {
+    return getJson<ApiDocument>(`/documents/${documentId}`);
   },
 
-  async updateDocumentDraft(documentId: string, draft: Partial<ApiDocumentDraft>): Promise<ApiDocument> {
+  async extractDocumentDraft(
+    documentId: string,
+    payload: { text: string },
+  ): Promise<ApiDocument> {
+    return postJson<ApiDocument>(`/documents/${documentId}/extract`, payload);
+  },
+
+  // backwards-compatible alias
+  async extractDocument(documentId: string, text: string): Promise<ApiDocument> {
+    return this.extractDocumentDraft(documentId, { text });
+  },
+
+  async updateDocumentDraft(
+    documentId: string,
+    draft: Partial<ApiDocumentDraft>,
+  ): Promise<ApiDocument> {
     return putJson<ApiDocument>(`/documents/${documentId}/draft`, { draft });
   },
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -261,6 +261,8 @@ export interface ApiDocument {
   documentId: string;
   imageUrl: string;
   status: 'UPLOADED' | 'DRAFT_READY' | 'CONFIRMED';
+  /** 문서 소스 타입 (현재는 외부 문서만 지원) */
+  sourceType: 'EXTERNAL_DOCUMENT';
   draft: ApiDocumentDraft | null;
   createdAt: string;
 }

--- a/src/screens/DocsImportScreen.tsx
+++ b/src/screens/DocsImportScreen.tsx
@@ -4,7 +4,9 @@ import { Camera, Image as ImageIcon, X, ChevronRight, FileText } from 'lucide-re
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
+// eslint-disable-next-line import/no-unresolved
 import * as DocumentPicker from 'expo-document-picker';
+// eslint-disable-next-line import/no-unresolved
 import TextRecognition from '@react-native-ml-kit/text-recognition';
 import { Colors, Radius, Shadows } from '@/constants/theme';
 import { httpClient } from '@/src/api/httpClient';
@@ -103,7 +105,7 @@ export default function DocsImportScreen() {
             
             // 2) Send text to the parsing API (if present)
             if (extractedText) {
-                await httpClient.extractDocument(doc.documentId, extractedText);
+                await httpClient.extractDocumentDraft(doc.documentId, { text: extractedText });
             }
             
             // Move to review screen with documentId

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -1,0 +1,7 @@
+// Ambient module declarations for libraries without TypeScript types.
+// These can be replaced with proper type definitions when available.
+
+declare module 'expo-document-picker';
+
+declare module '@react-native-ml-kit/text-recognition';
+


### PR DESCRIPTION
Closes #59

- documents import 관련 타입 추가
- documents REST 클라이언트 메서드(upload/get/extractDraft/updateDraft/confirm) 정의
- 외부 모듈 타입/ESLint 오류 해소를 위한 ambient declaration 추가

Made with [Cursor](https://cursor.com)