### PR TITLE
fix(ui): replace index-based keys with stable identifiers (#83)

### DIFF
--- a/src/components/molecules/CalendarStrip.tsx
+++ b/src/components/molecules/CalendarStrip.tsx
@@ -31,14 +31,14 @@ export function CalendarStrip({ dates, activeDateStr, onDateSelect, onViewAll, c
 
             {/* Strip */}
             <View style={styles.weekRow}>
-                {dates.map((date, idx) => {
+                {dates.map((date) => {
                     const dateStr = toLocalISOString(date);
                     const isSelected = dateStr === activeDateStr;
                     const hasClass = classesForDates[dateStr];
 
                     return (
                         <TouchableOpacity
-                            key={idx}
+                            key={dateStr}
                             style={[styles.dayContainer, isSelected && styles.todayContainer]}
                             onPress={() => onDateSelect(dateStr)}
                         >

--- a/src/components/organisms/BottomTabBar.tsx
+++ b/src/components/organisms/BottomTabBar.tsx
@@ -52,7 +52,7 @@ export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarPro
 
                     return (
                         <TouchableOpacity
-                            key={index}
+                            key={route.key}
                             accessibilityRole="button"
                             accessibilityState={isFocused ? { selected: true } : {}}
                             accessibilityLabel={options.tabBarAccessibilityLabel}

--- a/src/screens/AvailabilitySettingsScreen.tsx
+++ b/src/screens/AvailabilitySettingsScreen.tsx
@@ -541,8 +541,8 @@ export default function AvailabilitySettingsScreen() {
           {allConfiguredSlots.length === 0 ? (
             <Text style={styles.emptyText}>등록된 가능시간이 없습니다.</Text>
           ) : (
-            allConfiguredSlots.map((item, index) => (
-              <View key={`${item.date}-${index}`} style={styles.slotDisplayRow}>
+            allConfiguredSlots.map((item) => (
+              <View key={`${item.date}-${item.start}`} style={styles.slotDisplayRow}>
                 <Text style={styles.slotDisplayText}>
                   {item.date} {item.start}-{item.end}
                 </Text>


### PR DESCRIPTION
## Summary
- `BottomTabBar`: `key={index}` → `key={route.key}` (React Navigation이 부여한 고유 문자열)
- `CalendarStrip`: `key={idx}` → `key={dateStr}` (날짜 문자열 YYYY-MM-DD)
- `AvailabilitySettingsScreen`: `key=\`${date}-${index}\`` → `key=\`${date}-${startTime}\`` (날짜+시작시간)

## Test plan
- [ ] 앱 실행 후 Metro/LogBox에서 React key warning 미발생 확인
- [ ] BottomTabBar 탭 전환 정상 동작 확인
- [ ] CalendarStrip 주간 캘린더 날짜 선택 정상 동작 확인
- [ ] 가용시간 등록 후 목록 표시 정상 동작 확인

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)