### PR TITLE
feat(schedule): preserve lesson venue coordinates (closes #98)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -70,6 +70,11 @@ export interface ApiLesson {
   lectureTitle: string;
   region: string;
   museum: string;
+  venueName?: string;
+  venueAddress?: string;
+  venueLat?: number;
+  venueLng?: number;
+  kakaoPlaceId?: string;
   guideNotionUrl: string;
   payAmount: number;
   studentCount: number;

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -4,13 +4,18 @@ import { Alert } from 'react-native';
 import { apiClient } from '../api/apiClient';
 
 export interface ClassSession {
-    id: string;
-    title: string;
-    date: string; // YYYY-MM-DD format
-    location: string;
-    time: string;
-    isExternal?: boolean;
-    documentId?: string | null;
+  id: string;
+  title: string;
+  date: string; // YYYY-MM-DD format
+  location: string;
+  time: string;
+  isExternal?: boolean;
+  documentId?: string | null;
+  venueName?: string;
+  venueAddress?: string;
+  venueLat?: number;
+  venueLng?: number;
+  kakaoPlaceId?: string;
 }
 
 export interface AppNotification {
@@ -116,13 +121,18 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 )}:${pad(end.getMinutes())}`;
                 const location = `${lesson.region} ${lesson.museum}`;
                 return {
-                    id: lesson.lessonId,
-                    title: lesson.lectureTitle,
-                    date,
-                    location,
-                    time,
-                    isExternal: lesson.isExternal,
-                    documentId: lesson.documentId,
+                  id: lesson.lessonId,
+                  title: lesson.lectureTitle,
+                  date,
+                  location,
+                  time,
+                  isExternal: lesson.isExternal,
+                  documentId: lesson.documentId,
+                  venueName: lesson.venueName,
+                  venueAddress: lesson.venueAddress,
+                  venueLat: lesson.venueLat,
+                  venueLng: lesson.venueLng,
+                  kakaoPlaceId: lesson.kakaoPlaceId,
                 };
             });
             setClasses(mapped);


### PR DESCRIPTION
## Summary
- Extend ApiLesson with venueName/venueAddress/venueLat/venueLng/kakaoPlaceId from backend.
- Extend ScheduleContext ClassSession to keep venue fields and map them in fetchLessons.
- No UI behavior change yet; this only preserves data for later GPS smart notification features.

## Test plan
- npm run lint (passes with existing warnings, no new errors).
- Manual: launch app home screen and confirm schedule list still renders lessons without runtime errors.
- Manual: inspect mapped ClassSession via logging to ensure venue* fields are populated when backend sends them.

Made with [Cursor](https://cursor.com)