### PR TITLE
chore(docs): refine contracts screen interactions and error display

### DIFF
--- a/src/screens/DocContractDetailScreen.tsx
+++ b/src/screens/DocContractDetailScreen.tsx
@@ -145,9 +145,14 @@ export default function DocContractDetailScreen() {
   }
 
   if (errorCode || !detail) {
+    const message = getContractErrorMessage(errorCode ?? undefined);
+    const idInfo = contractId ? `\n(ID: ${contractId})` : '';
     return (
       <View style={styles.centered}>
-        <Text style={styles.errorText}>{getContractErrorMessage(errorCode ?? undefined)}</Text>
+        <Text style={styles.errorText}>
+          {message}
+          {idInfo}
+        </Text>
         <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
           <Text style={styles.backButtonText}>목록으로</Text>
         </TouchableOpacity>

--- a/src/screens/DocsScreen.tsx
+++ b/src/screens/DocsScreen.tsx
@@ -38,7 +38,9 @@ export default function DocsScreen() {
         setContractsError(null);
         setContractsLoading(true);
         httpClient.getContracts()
-            .then((list) => { if (mounted) setContracts(list); })
+            .then((list) => {
+                if (mounted) setContracts(list);
+            })
             .catch(() => {
                 if (mounted) {
                     setContracts([]);
@@ -249,7 +251,10 @@ export default function DocsScreen() {
 
                         {!requestsLoading && !requestsError && lessonRequests.map((req) => {
                             const isPending = req.status === 'PENDING';
-                            const isResponded = req.status === 'ACCEPTED' || req.status === 'REJECTED' || req.status === 'CANCELLED';
+                            const isResponded =
+                                req.status === 'ACCEPTED' ||
+                                req.status === 'REJECTED' ||
+                                req.status === 'CANCELLED';
                             const requestedDate = req.requestedAt.slice(0, 10);
                             const isRejectingThis = rejectModalOpenFor === req.requestId;
                             const isBusy = respondingRequestId === req.requestId;
@@ -270,28 +275,30 @@ export default function DocsScreen() {
                                     {req.rejectionReason && (
                                         <Text style={styles.requestItemMeta}>거절 사유: {req.rejectionReason}</Text>
                                     )}
-                                    <View style={styles.requestActions}>
-                                        <TouchableOpacity
-                                            style={[styles.acceptButton, (!isPending || isBusy) && { opacity: 0.6 }]}
-                                            onPress={() => handleRespond(req.requestId, 'ACCEPT')}
-                                            disabled={!isPending || isBusy}
-                                        >
-                                            <Text style={styles.acceptButtonText}>
-                                                {isBusy && isPending ? '처리 중...' : '수락'}
-                                            </Text>
-                                        </TouchableOpacity>
-                                        <TouchableOpacity
-                                            style={[styles.rejectButton, (!isPending || isBusy) && { opacity: 0.6 }]}
-                                            onPress={() => {
-                                                if (!isPending || isBusy) return;
-                                                setRejectModalOpenFor(isRejectingThis ? null : req.requestId);
-                                                setRejectReason('');
-                                            }}
-                                            disabled={!isPending || isBusy}
-                                        >
-                                            <Text style={styles.rejectButtonText}>거절</Text>
-                                        </TouchableOpacity>
-                                    </View>
+                                    {isPending && (
+                                        <View style={styles.requestActions}>
+                                            <TouchableOpacity
+                                                style={[styles.acceptButton, isBusy && { opacity: 0.6 }]}
+                                                onPress={() => handleRespond(req.requestId, 'ACCEPT')}
+                                                disabled={isBusy}
+                                            >
+                                                <Text style={styles.acceptButtonText}>
+                                                    {isBusy ? '처리 중...' : '수락'}
+                                                </Text>
+                                            </TouchableOpacity>
+                                            <TouchableOpacity
+                                                style={[styles.rejectButton, isBusy && { opacity: 0.6 }]}
+                                                onPress={() => {
+                                                    if (isBusy) return;
+                                                    setRejectModalOpenFor(isRejectingThis ? null : req.requestId);
+                                                    setRejectReason('');
+                                                }}
+                                                disabled={isBusy}
+                                            >
+                                                <Text style={styles.rejectButtonText}>거절</Text>
+                                            </TouchableOpacity>
+                                        </View>
+                                    )}
                                     {isPending && isRejectingThis && (
                                         <View style={styles.rejectInputContainer}>
                                             <TextInput


### PR DESCRIPTION
- Requests tab: 수락/거절 버튼을 PENDING 상태인 요청에만 표시하도록 변경
- 계약 상세 화면: 계약을 찾지 못했을 때 오류 메시지에 contractId를 함께 노출 (ID: ...)

기존 동작(계약 리스트/상세 조회, 서명 플로우 등)은 그대로 유지됩니다.

Made with [Cursor](https://cursor.com)