### PR TITLE
fix(app): harden docs flow, check-in, and auth edge cases

### DIFF
--- a/__tests__/issue78-lesson-reports-backend.test.ts
+++ b/__tests__/issue78-lesson-reports-backend.test.ts
@@ -209,7 +209,7 @@ describe('optimisticAdd', () => {
 
     test('T19 — 원본 배열/객체 불변', () => {
         const ids = ['L000'];
-        const reports = { L000: '기존' };
+        const reports: Record<string, string> = { L000: '기존' };
         optimisticAdd(ids, reports, 'L001', '새');
         expect(ids).toHaveLength(1);
         expect(reports['L001']).toBeUndefined();

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -118,6 +118,10 @@ interface RequestOptions extends RequestInit {
   retryOnUnauthorized?: boolean;
 }
 
+function isFormDataBody(body: RequestInit['body'] | null | undefined): body is FormData {
+  return typeof FormData !== 'undefined' && body instanceof FormData;
+}
+
 let authFailureHandler: AuthFailureHandler = () => {
   router.replace('/login');
 };
@@ -178,7 +182,7 @@ async function requestJson<T>(path: string, options: RequestOptions = {}): Promi
   } = options;
 
   const requestHeaders = new Headers(headers);
-  if (init.body && !requestHeaders.has('Content-Type')) {
+  if (init.body && !isFormDataBody(init.body) && !requestHeaders.has('Content-Type')) {
     requestHeaders.set('Content-Type', 'application/json');
   }
 
@@ -541,27 +545,10 @@ export const httpClient = {
     if (documentType) {
       formData.append('type', documentType);
     }
-
-    const accessToken = await getAccessToken();
-    const response = await fetch(`${API_BASE_URL}/documents/upload`, {
+    return requestJson<ApiDocument>('/documents/upload', {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: formData as any,
+      body: formData,
     });
-
-    if (!response.ok) {
-      const err = await buildApiError(response, '/documents');
-      // eslint-disable-next-line no-console
-      console.log('[httpClient] upload error', {
-        status: err.status,
-        code: err.code,
-        message: err.message,
-      });
-      throw err;
-    }
-    return response.json();
   },
 
   async getDocument(documentId: string): Promise<ApiDocument> {

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -237,9 +237,10 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         // 2. If can end class, handle end class
         if (canEndClassIds.includes(id) && !endedClassIds.includes(id)) {
             const requestId = lessonRequestMap[id];
+            let coords: Awaited<ReturnType<typeof getLocationForCheckin>> = null;
             if (requestId) {
                 try {
-                    const coords = await getLocationForCheckin();
+                    coords = await getLocationForCheckin();
                     await apiClient.checkinByAssignment(requestId, {
                         eventType: 'FINISH',
                         idempotencyKey: `FINISH_${requestId}_${Date.now()}`,
@@ -280,9 +281,10 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         // 3. If can arrive, handle arrive
         if (canArriveIds.includes(id) && !arrivedIds.includes(id)) {
             const requestId = lessonRequestMap[id];
+            let coords: Awaited<ReturnType<typeof getLocationForCheckin>> = null;
             if (requestId) {
                 try {
-                    const coords = await getLocationForCheckin();
+                    coords = await getLocationForCheckin();
                     await apiClient.checkinByAssignment(requestId, {
                         eventType: 'ARRIVE',
                         idempotencyKey: `ARRIVE_${requestId}_${Date.now()}`,

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -73,10 +73,23 @@ export default function AppSettingsScreen() {
     };
 
     const handleConfirmLogout = async () => {
+        let pushCleanupFailed = false;
+
         try {
             await deregisterPushDevice();
+        } catch {
+            pushCleanupFailed = true;
+        }
+
+        try {
             await clearTokens();
             router.replace('/login');
+            if (pushCleanupFailed) {
+                Alert.alert(
+                    '로그아웃 완료',
+                    '세션은 종료되었지만 푸시 디바이스 해제는 완료되지 않았습니다.',
+                );
+            }
         } catch {
             Alert.alert('로그아웃 실패', '로그아웃 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
         }

--- a/src/screens/DocLessonRequestDetailScreen.tsx
+++ b/src/screens/DocLessonRequestDetailScreen.tsx
@@ -90,7 +90,13 @@ export default function DocLessonRequestDetailScreen() {
         Alert.alert(
           '수락 완료',
           '요청을 수락하여 새로운 계약서가 발송되었습니다.',
-          [{ text: '계약 확인하기', onPress: () => router.replace('/docs?targetTab=계약' as any) }],
+          [{
+            text: '계약 확인하기',
+            onPress: () => router.replace({
+              pathname: '/(tabs)/docs',
+              params: { targetTab: '계약' },
+            }),
+          }],
         );
       }
     } catch (error: unknown) {

--- a/src/screens/DocsImportScreen.tsx
+++ b/src/screens/DocsImportScreen.tsx
@@ -21,6 +21,7 @@ export default function DocsImportScreen() {
     const [errorMessage, setErrorMessage] = useState('');
     const [isPdf, setIsPdf] = useState(false);
     const [pdfFileName, setPdfFileName] = useState('');
+    const [uploadedDocumentId, setUploadedDocumentId] = useState<string | null>(null);
 
     const pickImage = async (useCamera: boolean) => {
         try {
@@ -54,6 +55,7 @@ export default function DocsImportScreen() {
                 setErrorMessage('');
                 setIsPdf(false);
                 setPdfFileName('');
+                setUploadedDocumentId(null);
             }
         } catch (error) {
             console.error('Image picking error:', error);
@@ -74,6 +76,7 @@ export default function DocsImportScreen() {
                 setPdfFileName(result.assets[0].name);
                 setOcrFailed(false);
                 setErrorMessage('');
+                setUploadedDocumentId(null);
             }
         } catch (error) {
             console.error('Document picking error:', error);
@@ -85,32 +88,48 @@ export default function DocsImportScreen() {
         if (!imageUri) return;
 
         setIsUploading(true);
+        let documentId = uploadedDocumentId;
         try {
-            let extractedText = '';
-
-            if (!isPdf) {
-                const recognizeResult = await TextRecognition.recognize(imageUri);
-                extractedText = recognizeResult.text?.trim() || '';
-
-                if (!extractedText) {
-                    setOcrFailed(true);
-                    setErrorMessage('이미지에서 글자를 찾을 수 없습니다.\n다시 촬영하시거나 직접 입력해주세요.');
-                    setIsUploading(false);
-                    return;
-                }
-            }
-
-            // 1) Upload image/document to get documentId
             const mimeType = isPdf ? 'application/pdf' : 'image/jpeg';
             const fileName = isPdf ? (pdfFileName || 'document.pdf') : 'document.jpg';
             const documentType = isPdf ? 'CONTRACT_PDF' : 'CONTRACT_IMAGE';
-            const doc = await httpClient.uploadDocument(imageUri, mimeType, fileName, documentType);
+
+            if (!documentId) {
+                const doc = await httpClient.uploadDocument(
+                    imageUri,
+                    mimeType,
+                    fileName,
+                    documentType,
+                );
+                documentId = doc.documentId;
+                setUploadedDocumentId(documentId);
+            }
+
+            let extractedText = '';
+            if (!isPdf) {
+                const recognizeResult = await TextRecognition.recognize(imageUri);
+                extractedText = recognizeResult.text?.trim() || '';
+            }
+
+            if (!isPdf && !extractedText) {
+                setOcrFailed(true);
+                setErrorMessage('이미지에서 글자를 찾을 수 없습니다.\n다시 촬영하시거나 직접 입력해주세요.');
+                return;
+            }
 
             // 2) Send to the parsing API (server takes care of PDF text extraction if ocrText is omitted)
-            await httpClient.extractDocumentDraft(doc.documentId, { ocrText: extractedText || undefined });
+            await httpClient.extractDocumentDraft(documentId, {
+                ocrText: extractedText || undefined,
+            });
 
             // Move to review screen with documentId
-            router.push(`/docs/review?documentId=${doc.documentId}&imageUri=${encodeURIComponent(imageUri)}` as any);
+            router.push({
+                pathname: '/docs/review',
+                params: {
+                    documentId,
+                    imageUri,
+                },
+            });
         } catch (error: any) {
             console.error('OCR/Upload error:', error);
             setOcrFailed(true);
@@ -164,7 +183,26 @@ export default function DocsImportScreen() {
                                     <TouchableOpacity style={styles.retakeButtonSmall} onPress={() => { setOcrFailed(false); setImageUri(null); }}>
                                         <Text style={styles.retakeButtonTextSmall}>다시 선택하기</Text>
                                     </TouchableOpacity>
-                                    <TouchableOpacity style={styles.manualEntryButton} onPress={() => router.push('/docs/review' as any)}>
+                                    <TouchableOpacity
+                                        style={styles.manualEntryButton}
+                                        onPress={() => {
+                                            if (!uploadedDocumentId) {
+                                                Alert.alert(
+                                                    '문서 업로드 필요',
+                                                    '문서 업로드가 완료되지 않아 직접 입력을 이어갈 수 없습니다. 다시 시도해주세요.',
+                                                );
+                                                return;
+                                            }
+
+                                            router.push({
+                                                pathname: '/docs/review',
+                                                params: {
+                                                    documentId: uploadedDocumentId,
+                                                    imageUri,
+                                                },
+                                            });
+                                        }}
+                                    >
                                         <Text style={styles.manualEntryButtonText}>직접 입력하기</Text>
                                     </TouchableOpacity>
                                 </View>

--- a/src/screens/DocsReviewScreen.tsx
+++ b/src/screens/DocsReviewScreen.tsx
@@ -8,14 +8,35 @@ import { httpClient } from '@/src/api/httpClient';
 import type { ApiDocumentDraft } from '@/src/api/types';
 import { useSchedule } from '../context/ScheduleContext';
 
+function getSingleParam(
+    value: string | string[] | undefined,
+): string | undefined {
+    return typeof value === 'string'
+        ? value
+        : Array.isArray(value)
+          ? value[0]
+          : undefined;
+}
+
+function toEditableDateTime(value: string | null | undefined): string {
+    if (!value) {
+        return '';
+    }
+
+    return value.replace('T', ' ').trim().slice(0, 16);
+}
+
 export default function DocsReviewScreen() {
     const insets = useSafeAreaInsets();
     const router = useRouter();
-    const params = useLocalSearchParams();
+    const params = useLocalSearchParams<{
+        documentId?: string | string[];
+        imageUri?: string | string[];
+    }>();
     
     const { fetchLessons, classes } = useSchedule();
-    const documentId = params.documentId as string;
-    const imageUri = params.imageUri as string;
+    const documentId = getSingleParam(params.documentId);
+    const imageUri = getSingleParam(params.imageUri);
 
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -46,8 +67,8 @@ export default function DocsReviewScreen() {
                     setDraft({
                         lectureTitle: parsed.lectureTitle || '',
                         companyName: parsed.companyName || '',
-                        startsAt: parsed.startsAt?.split('T')[0] || '',
-                        endsAt: parsed.endsAt?.split('T')[0] || '',
+                        startsAt: toEditableDateTime(parsed.startsAt),
+                        endsAt: toEditableDateTime(parsed.endsAt),
                         region: parsed.region || '',
                         museum: parsed.museum || '',
                         payAmount: parsed.payAmount || null,
@@ -153,6 +174,11 @@ export default function DocsReviewScreen() {
     };
 
     const handleSave = async () => {
+        if (!documentId) {
+            Alert.alert('등록 실패', '문서 ID가 없어 저장할 수 없습니다. 문서를 다시 업로드해주세요.');
+            return;
+        }
+
         if (!draft.lectureTitle || !draft.startsAt || !draft.endsAt) {
             Alert.alert('필수 입력', '강의명, 시작일시, 종료일시는 필수입니다.');
             return;

--- a/src/screens/DocsScreen.tsx
+++ b/src/screens/DocsScreen.tsx
@@ -1,5 +1,5 @@
 import { Colors, Radius, Shadows } from '@/constants/theme';
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput, ActivityIndicator, Alert, Pressable } from 'react-native';
 import { Bell, Camera, FileText } from 'lucide-react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -9,15 +9,20 @@ import { SegmentedTabs } from '@/src/components/molecules/SegmentedTabs';
 import { NotificationTopBar } from '@/src/components/organisms/NotificationTopBar';
 import { useContractsQuery, useLessonRequestsQuery, useRespondToRequestMutation } from '../query/hooks';
 
+const DOCS_TABS = ['서류', '계약', '요청/제안'] as const;
+
 export default function DocsScreen() {
     const insets = useSafeAreaInsets();
     const router = useRouter();
-    const params = useLocalSearchParams();
+    const params = useLocalSearchParams<{ targetTab?: string | string[] }>();
+    const targetTab = typeof params.targetTab === 'string'
+        ? params.targetTab
+        : Array.isArray(params.targetTab)
+          ? params.targetTab[0]
+          : undefined;
 
-    const tabs = ['서류', '계약', '요청/제안'];
-    const initialTabIndex = params.targetTab ? tabs.indexOf(params.targetTab as string) : 0;
-    const [selectedTabIndex, setSelectedTabIndex] = useState(initialTabIndex >= 0 ? initialTabIndex : 0);
-    const selectedTab = tabs[selectedTabIndex];
+    const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+    const selectedTab = DOCS_TABS[selectedTabIndex];
     const contractFilterStatuses: (ContractStatus | 'ALL')[] = ['ALL', 'SENT', 'INSTRUCTOR_SIGNED', 'FULLY_SIGNED'];
     const [contractStatusFilter, setContractStatusFilter] = useState<ContractStatus | 'ALL'>('ALL');
     const [rejectModalOpenFor, setRejectModalOpenFor] = useState<string | null>(null);
@@ -32,6 +37,17 @@ export default function DocsScreen() {
     const contractsError = contractsQuery.isError ? '계약 목록을 불러오지 못했습니다.' : null;
     const requestsError = lessonRequestsQuery.isError ? '수업 요청 목록을 불러오지 못했습니다.' : null;
     const respondingRequestId = respondToRequestMutation.variables?.requestId ?? null;
+
+    useEffect(() => {
+        if (!targetTab) {
+            return;
+        }
+
+        const nextIndex = DOCS_TABS.indexOf(targetTab as (typeof DOCS_TABS)[number]);
+        if (nextIndex >= 0) {
+            setSelectedTabIndex(nextIndex);
+        }
+    }, [targetTab]);
 
     const contractStatusLabel = (s: ContractStatus): string => {
         const map: Record<ContractStatus, string> = {
@@ -150,7 +166,7 @@ export default function DocsScreen() {
 
             {/* Top Tabs (Segmented) */}
             <SegmentedTabs
-                tabs={tabs}
+                tabs={[...DOCS_TABS]}
                 activeIndex={selectedTabIndex}
                 onChange={setSelectedTabIndex}
             />
@@ -165,7 +181,7 @@ export default function DocsScreen() {
                         {/* 외부 계약서 등록 CTA 카드 */}
                         <TouchableOpacity 
                             style={styles.importCard} 
-                            onPress={() => router.push('/docs/import' as any)}
+                            onPress={() => router.push({ pathname: '/docs/import' })}
                         >
                             <View style={styles.importIconContainer}>
                                 <Camera color={Colors.brandInk} size={24} />
@@ -226,7 +242,10 @@ export default function DocsScreen() {
                                         </View>
                                         <TouchableOpacity
                                             style={styles.viewButton}
-                                            onPress={() => router.push(`/docs/contract?contractId=${encodeURIComponent(c.contractId)}`)}
+                                            onPress={() => router.push({
+                                                pathname: '/(tabs)/docs/contract',
+                                                params: { contractId: c.contractId },
+                                            })}
                                         >
                                             <Text style={styles.viewButtonText}>보기</Text>
                                         </TouchableOpacity>
@@ -304,7 +323,10 @@ export default function DocsScreen() {
                                         styles.pendingRequestItemCard,
                                         pressed && styles.requestItemCardPressed,
                                     ]}
-                                    onPress={() => router.push(`/docs/request?requestId=${encodeURIComponent(req.requestId)}`)}
+                                    onPress={() => router.push({
+                                        pathname: './request',
+                                        params: { requestId: req.requestId },
+                                    })}
                                 >
                                     <View style={styles.requestItemHeader}>
                                         <Text style={styles.requestItemTitle}>{lessonTitle}</Text>
@@ -397,7 +419,10 @@ export default function DocsScreen() {
                                         styles.requestItemCard,
                                         pressed && styles.requestItemCardPressed,
                                     ]}
-                                    onPress={() => router.push(`/docs/request?requestId=${encodeURIComponent(req.requestId)}`)}
+                                    onPress={() => router.push({
+                                        pathname: './request',
+                                        params: { requestId: req.requestId },
+                                    })}
                                 >
                                     <View style={styles.requestItemHeader}>
                                         <Text style={styles.requestItemTitle}>{lessonTitle}</Text>


### PR DESCRIPTION
## Summary
- fix arrive/finish check-in runtime failure caused by out-of-scope `coords`
- harden docs import/review flow for manual entry, datetime preservation, and tab routing sync
- make logout resilient to push deregistration failure and move document upload onto shared auth refresh flow
- fix the remaining TypeScript test typing blocker found during integration

## Validation
- `npx tsc --noEmit`
- `npx jest --runInBand`
- `npm run lint` (warnings only, no new errors)
- web smoke check reached the login screen on `http://localhost:8082`
- login-after-load web flow is currently blocked by backend CORS on `https://free-b-api-production.up.railway.app/auth/demo-login`

## Issues
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
