### PR TITLE
서류/계약 제안 탭 응답 완료 이력 장소 표시 개선

### DIFF
--- a/src/screens/DocLessonRequestDetailScreen.tsx
+++ b/src/screens/DocLessonRequestDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import type { ApiLessonRequest } from '../api/types';
+import { formatLessonCardLocation } from '../utils/lessonCardLocation';
 import { useLessonRequestsQuery, useRespondToRequestMutation } from '../query/hooks';
 
 function formatLessonSchedule(req: ApiLessonRequest): string {
@@ -42,10 +43,12 @@ function formatLessonSchedule(req: ApiLessonRequest): string {
 }
 
 function formatLessonLocation(req: ApiLessonRequest): string {
-  const parts = [req.region, req.museum, req.venueName].filter(
-    (value): value is string => Boolean(value && value.trim()),
-  );
-  return parts.length > 0 ? parts.join(' · ') : '장소 정보 없음';
+  const loc = formatLessonCardLocation({
+    region: req.region ?? '',
+    museum: req.museum,
+    venueName: req.venueName,
+  });
+  return loc || '장소 정보 없음';
 }
 
 function lessonRequestStatusLabel(status: ApiLessonRequest['status']): string {

--- a/src/screens/DocsScreen.tsx
+++ b/src/screens/DocsScreen.tsx
@@ -5,6 +5,7 @@ import { Bell, Camera, FileText } from 'lucide-react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { ApiContract, ApiLessonRequest, ContractStatus } from '../api/types';
+import { formatLessonCardLocation } from '../utils/lessonCardLocation';
 import { SegmentedTabs } from '@/src/components/molecules/SegmentedTabs';
 import { NotificationTopBar } from '@/src/components/organisms/NotificationTopBar';
 import { useContractsQuery, useLessonRequestsQuery, useRespondToRequestMutation } from '../query/hooks';
@@ -106,10 +107,12 @@ export default function DocsScreen() {
     };
 
     const formatLessonLocation = (req: ApiLessonRequest): string => {
-        const parts = [req.region, req.museum, req.venueName].filter(
-            (value): value is string => Boolean(value && value.trim()),
-        );
-        return parts.length > 0 ? parts.join(' · ') : '장소 정보 없음';
+        const loc = formatLessonCardLocation({
+            region: req.region ?? '',
+            museum: req.museum,
+            venueName: req.venueName,
+        });
+        return loc || '장소 정보 없음';
     };
 
     const lessonRequestStatusLabel = (status: ApiLessonRequest['status']): string => {


### PR DESCRIPTION
## 변경 내용
- **서류/계약 → 제안 탭 → 응답 완료 이력** 리스트에서 장소 문자열 표시 규칙 적용
  - `venueName`이 있으면 `venueName`만 표시
  - 없으면 `region`, `museum` 사용 시 **중복 제거** 후 표시 (예: 허준박물관 / 허준박물관 → 허준박물관)
  - 장소 정보가 없으면 "장소 정보 없음" 표시
- 제안 요청 **상세 화면**에서도 동일한 장소 포맷 사용하도록 수정

## 수정 파일
- `src/screens/DocsScreen.tsx` — `formatLessonLocation`에서 `formatLessonCardLocation` 사용
- `src/screens/DocLessonRequestDetailScreen.tsx` — 상세 화면 장소 포맷 통일

Closes #136
