### PR TITLE
feat(app): 강사 서명 이미지 등록/관리 화면 추가 (#163)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -132,6 +132,7 @@ export default function RootLayout() {
         <Stack.Screen name="profile/career-detail" options={{ title: '강의 이력 상세' }} />
         <Stack.Screen name="profile/region" options={{ title: '희망 지역' }} />
         <Stack.Screen name="profile/settings" options={{ title: '앱 설정' }} />
+        <Stack.Screen name="profile/signature" options={{ title: '서명 이미지 관리' }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/profile/signature.tsx
+++ b/app/profile/signature.tsx
@@ -1,0 +1,5 @@
+import SignatureSettingScreen from '@/src/screens/SignatureSettingScreen';
+
+export default function SignatureRoute() {
+  return <SignatureSettingScreen />;
+}

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -22,6 +22,7 @@ import {
   ApiNotificationSettings,
   ApiPushDevice,
   ApiSettlement,
+  ApiSignatureAsset,
   AuthLoginResponse,
   LectureRecordView,
   NotificationSettingsUpdate,
@@ -586,6 +587,25 @@ export const httpClient = {
 
   async deregisterPushDevice(deviceId: string): Promise<void> {
     return deleteJson<void>(`/push/devices/${encodeURIComponent(deviceId)}`);
+  },
+
+  // ---- Instructor Signature Asset API ----
+
+  async getSignatureAsset(): Promise<ApiSignatureAsset> {
+    return getJson<ApiSignatureAsset>('/instructors/me/signature-image');
+  },
+
+  async uploadSignatureAsset(fileUri: string): Promise<ApiSignatureAsset> {
+    const formData = new FormData();
+    formData.append('file', {
+      uri: fileUri,
+      name: 'signature.png',
+      type: 'image/png',
+    } as any);
+    return requestJson<ApiSignatureAsset>('/instructors/me/signature-image', {
+      method: 'PUT',
+      body: formData,
+    });
   },
 
   // ---- Notification Settings API ----

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -317,6 +317,20 @@ export interface ApiSettlementSummary {
   scheduledPayDate?: string | null;
 }
 
+// ---- Instructor Signature Asset Types ----
+
+export interface ApiSignatureAsset {
+  signatureAssetId: string;
+  instructorId: string;
+  fileUrl: string;
+  mimeType: string;
+  width: number;
+  height: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ---- Document Import API Types ----
 
 export interface ApiDocumentDraft {

--- a/src/query/hooks.ts
+++ b/src/query/hooks.ts
@@ -15,6 +15,7 @@ import type {
   ApiLesson,
   ApiLessonReport,
   ApiLessonRequest,
+  ApiSignatureAsset,
   SubmitContractSignaturePayload,
 } from '../api/types';
 import { queryKeys } from './queryKeys';
@@ -164,6 +165,33 @@ export function useChatMessagesQuery(
     queryFn: () => httpClient.getChatMessages(roomId!),
     enabled: Boolean(roomId),
     ...options,
+  });
+}
+
+export function useSignatureAssetQuery(
+  options?: Omit<UseQueryOptions<ApiSignatureAsset | null>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery<ApiSignatureAsset | null>({
+    queryKey: queryKeys.signatureAsset,
+    queryFn: async () => {
+      try {
+        return await httpClient.getSignatureAsset();
+      } catch (e) {
+        if ((e as { status?: number }).status === 404) return null;
+        throw e;
+      }
+    },
+    ...options,
+  });
+}
+
+export function useUploadSignatureMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fileUri: string) => httpClient.uploadSignatureAsset(fileUri),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.signatureAsset });
+    },
   });
 }
 

--- a/src/query/queryKeys.ts
+++ b/src/query/queryKeys.ts
@@ -9,4 +9,5 @@ export const queryKeys = {
   attendanceEvents: ['attendance-events'] as const,
   lessonReports: ['lesson-reports'] as const,
   instructorProfile: ['instructor-profile'] as const,
+  signatureAsset: ['signature-asset'] as const,
 } as const;

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -3,7 +3,7 @@ import { useProfile } from '@/src/context/ProfileContext';
 import { apiClient } from '@/src/api/apiClient';
 import type { ApiCompany, ApiInstructorProfile } from '@/src/api/types';
 import { useRouter } from 'expo-router';
-import { Briefcase, ChevronRight, Clock, MapPin, Settings, UserCircle } from 'lucide-react-native';
+import { Briefcase, ChevronRight, Clock, MapPin, PenLine, Settings, UserCircle } from 'lucide-react-native';
 import React, { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -83,6 +83,14 @@ export default function ProfileScreen() {
                         <Briefcase color={Colors.brandInk} size={20} />
                     </View>
                     <Text style={styles.menuText}>강의 이력</Text>
+                    <ChevronRight color="#CBD5E1" size={20} />
+                </TouchableOpacity>
+
+                <TouchableOpacity style={styles.menuItem} onPress={() => router.push('/profile/signature')}>
+                    <View style={styles.menuIconContainer}>
+                        <PenLine color={Colors.brandInk} size={20} />
+                    </View>
+                    <Text style={styles.menuText}>서명 이미지 관리</Text>
                     <ChevronRight color="#CBD5E1" size={20} />
                 </TouchableOpacity>
 

--- a/src/screens/SignatureSettingScreen.tsx
+++ b/src/screens/SignatureSettingScreen.tsx
@@ -1,0 +1,160 @@
+import { Colors, Radius, Shadows } from '@/constants/theme';
+import { API_BASE_URL } from '@/src/api/httpClient';
+import { SignaturePad } from '@/src/components/molecules/SignaturePad';
+import { useSignatureAssetQuery, useUploadSignatureMutation } from '@/src/query/hooks';
+import { getAccessToken } from '@/src/store/authStore';
+import { File, Paths } from 'expo-file-system';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+export default function SignatureSettingScreen() {
+  const { data: signatureAsset, isLoading } = useSignatureAssetQuery();
+  const uploadMutation = useUploadSignatureMutation();
+  const [pendingSignature, setPendingSignature] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAccessToken().then(setAccessToken);
+  }, []);
+
+  const handleSave = async () => {
+    if (!pendingSignature) return;
+    try {
+      const base64 = pendingSignature.split(',')[1];
+      const tempFile = new File(Paths.cache, 'signature_upload.png');
+      // Decode base64 to Uint8Array and write
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      tempFile.write(bytes);
+      await uploadMutation.mutateAsync(tempFile.uri);
+      setPendingSignature(null);
+      setAccessToken(await getAccessToken());
+      Alert.alert('저장 완료', '서명 이미지가 저장되었습니다.');
+    } catch {
+      Alert.alert('저장 실패', '서명 이미지를 저장하지 못했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <ActivityIndicator size="large" color={Colors.brandHoney} />
+      </View>
+    );
+  }
+
+  const currentSignatureSource =
+    signatureAsset && accessToken
+      ? {
+          uri: `${API_BASE_URL}${signatureAsset.fileUrl}`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      : null;
+
+  return (
+    <View style={styles.container}>
+      {/* 현재 서명 */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>현재 등록된 서명</Text>
+        <View style={styles.previewCard}>
+          {currentSignatureSource ? (
+            <Image
+              source={currentSignatureSource}
+              style={styles.signatureImage}
+              resizeMode="contain"
+            />
+          ) : (
+            <Text style={styles.emptyText}>등록된 서명이 없습니다</Text>
+          )}
+        </View>
+      </View>
+
+      {/* 새 서명 미리보기 */}
+      {pendingSignature ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>새 서명 미리보기</Text>
+          <View style={styles.previewCard}>
+            <Image
+              source={{ uri: pendingSignature }}
+              style={styles.signatureImage}
+              resizeMode="contain"
+            />
+          </View>
+        </View>
+      ) : null}
+
+      {/* 서명 캔버스 */}
+      <View style={styles.padSection}>
+        <Text style={styles.sectionTitle}>새 서명 그리기</Text>
+        <Text style={styles.hint}>서명 완료 후 하단 저장 버튼을 눌러주세요</Text>
+        <SignaturePad
+          onOK={setPendingSignature}
+          descriptionText="아래 영역에 서명해 주세요"
+          confirmText="서명 완료"
+        />
+      </View>
+
+      {/* 저장 버튼 */}
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[
+            styles.saveButton,
+            (!pendingSignature || uploadMutation.isPending) && styles.saveButtonDisabled,
+          ]}
+          onPress={handleSave}
+          disabled={!pendingSignature || uploadMutation.isPending}
+        >
+          <Text style={styles.saveButtonText}>
+            {uploadMutation.isPending ? '저장 중...' : '저장'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  centered: { justifyContent: 'center', alignItems: 'center' },
+  section: { paddingHorizontal: 16, paddingTop: 16 },
+  padSection: { flex: 1, paddingHorizontal: 16, paddingTop: 16 },
+  sectionTitle: { fontSize: 14, fontWeight: '700', color: '#374151', marginBottom: 8 },
+  hint: { fontSize: 12, color: '#9CA3AF', marginBottom: 10 },
+  previewCard: {
+    backgroundColor: 'white',
+    borderRadius: Radius.card,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 100,
+    ...Shadows.card,
+  },
+  signatureImage: { width: '100%', height: '100%' },
+  emptyText: { fontSize: 13, color: '#9CA3AF' },
+  footer: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+    paddingTop: 12,
+    backgroundColor: Colors.card,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  saveButton: {
+    backgroundColor: Colors.brandHoney,
+    padding: 16,
+    ...Radius.button,
+    alignItems: 'center',
+  },
+  saveButtonDisabled: { backgroundColor: Colors.border, opacity: 0.6 },
+  saveButtonText: { color: Colors.brandInk, fontSize: 16, fontWeight: 'bold' },
+});


### PR DESCRIPTION
## Summary
- `ApiSignatureAsset` 타입 및 `getSignatureAsset` / `uploadSignatureAsset` API 메서드 추가
- `useSignatureAssetQuery` / `useUploadSignatureMutation` React Query 훅 추가
- `SignatureSettingScreen`: 현재 서명 조회 + SignaturePad 그리기 + PNG 업로드 연동
- `app/profile/signature` 라우트 추가, `_layout.tsx`에 등록 (bottom tab 숨김)
- `ProfileScreen` 메뉴에 서명 이미지 관리 항목 추가

## Test plan
- [ ] 서명 없는 상태에서 화면 진입 → "등록된 서명 없음" 표시
- [ ] 서명 캔버스에서 그리기 → 서명 완료 → 미리보기 표시
- [ ] 저장 버튼 → PUT 업로드 성공 → "저장 완료" Alert
- [ ] 저장 후 화면 재진입 → 등록된 서명 이미지 표시

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)