### PR TITLE
feat(app): 완료 계약 PDF 열람 연동 추가 (#164)

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -26,7 +26,9 @@ import {
   AuthLoginResponse,
   LectureRecordView,
   NotificationSettingsUpdate,
+  PdfGenerationStatus,
 } from './types';
+import { File, Paths } from 'expo-file-system';
 import type { SubmitContractSignaturePayload } from './types';
 import {
   clearTokens,
@@ -107,6 +109,7 @@ interface BackendContractSignature {
 interface BackendContractDetailDto extends ApiContract {
   latestVersion?: BackendContractVersionSummary | null;
   signatures?: BackendContractSignature[];
+  pdfGenerationStatus?: PdfGenerationStatus;
 }
 
 interface RequestOptions extends RequestInit {
@@ -293,6 +296,7 @@ function toApiContractDetail(contract: BackendContractDetailDto): ApiContractDet
       instructorName: contract.instructorName,
       effectiveFrom: contract.effectiveFrom,
       effectiveTo: contract.effectiveTo,
+      pdfGenerationStatus: contract.pdfGenerationStatus,
     },
     currentVersion: contract.latestVersion
       ? {
@@ -587,6 +591,32 @@ export const httpClient = {
 
   async deregisterPushDevice(deviceId: string): Promise<void> {
     return deleteJson<void>(`/push/devices/${encodeURIComponent(deviceId)}`);
+  },
+
+  // ---- Contract Final PDF API ----
+
+  async downloadContractFinalPdf(contractId: string): Promise<string> {
+    const accessToken = await getAccessToken();
+    const response = await fetch(
+      `${BASE_URL}/contracts/${encodeURIComponent(contractId)}/final-pdf/file`,
+      { headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {} },
+    );
+    if (!response.ok) {
+      const err = await buildApiError(response, `/contracts/${contractId}/final-pdf/file`);
+      throw err;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+    const tempFile = new File(Paths.cache, `contract_${contractId}.pdf`);
+    tempFile.write(bytes);
+    return tempFile.uri;
+  },
+
+  async regenerateContractFinalPdf(contractId: string): Promise<ApiContractDetail> {
+    const contract = await postJson<BackendContractDetailDto>(
+      `/contracts/${encodeURIComponent(contractId)}/final-pdf/regenerate`,
+    );
+    return toApiContractDetail(contract);
   },
 
   // ---- Instructor Signature Asset API ----

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -105,6 +105,8 @@ export interface ApiLessonRequest {
   venueName?: string | null;
 }
 
+export type PdfGenerationStatus = 'PENDING' | 'GENERATING' | 'READY' | 'FAILED';
+
 export interface ApiContract {
   contractId: string;
   companyId: string;
@@ -120,6 +122,8 @@ export interface ApiContract {
   instructorName?: string;
   effectiveFrom?: string; // ISO date
   effectiveTo?: string;   // ISO date
+  /** 최종 PDF 생성 상태 (FULLY_SIGNED 계약에서만 의미 있음) */
+  pdfGenerationStatus?: PdfGenerationStatus;
 }
 
 /** 계약 서명자 역할 */

--- a/src/screens/DocContractDetailScreen.tsx
+++ b/src/screens/DocContractDetailScreen.tsx
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
   Modal,
   Alert,
+  Linking,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
@@ -45,6 +46,8 @@ export default function DocContractDetailScreen() {
   const [signTokenExpiresAt, setSignTokenExpiresAt] = useState<string | null>(null);
   const [reauthLoading, setReauthLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
 
   const loadContract = useCallback(async () => {
     if (!contractId) {
@@ -69,6 +72,33 @@ export default function DocContractDetailScreen() {
   useEffect(() => {
     loadContract();
   }, [loadContract]);
+
+  const handleOpenPdf = async () => {
+    if (!contractId) return;
+    setPdfLoading(true);
+    try {
+      const fileUri = await apiClient.downloadContractFinalPdf(contractId);
+      await Linking.openURL(fileUri);
+    } catch {
+      Alert.alert('열람 실패', 'PDF를 불러오지 못했습니다. 다시 시도해주세요.');
+    } finally {
+      setPdfLoading(false);
+    }
+  };
+
+  const handleRegeneratePdf = async () => {
+    if (!contractId) return;
+    setRegenerating(true);
+    try {
+      const updated = await apiClient.regenerateContractFinalPdf(contractId);
+      setDetail(updated);
+      Alert.alert('재생성 요청 완료', 'PDF 생성이 시작되었습니다. 잠시 후 다시 확인해주세요.');
+    } catch {
+      Alert.alert('재생성 실패', 'PDF 재생성 요청에 실패했습니다.');
+    } finally {
+      setRegenerating(false);
+    }
+  };
 
   const handleOpenSign = async () => {
     if (!contractId) return;
@@ -234,6 +264,45 @@ export default function DocContractDetailScreen() {
             </View>
           )}
 
+          {contract.status === 'FULLY_SIGNED' ? (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>최종 PDF</Text>
+              {contract.pdfGenerationStatus === 'READY' ? (
+                <TouchableOpacity
+                  style={[styles.pdfButton, pdfLoading && styles.pdfButtonDisabled]}
+                  onPress={handleOpenPdf}
+                  disabled={pdfLoading}
+                >
+                  {pdfLoading ? (
+                    <ActivityIndicator size="small" color={Colors.brandInk} />
+                  ) : (
+                    <Text style={styles.pdfButtonText}>PDF 열람</Text>
+                  )}
+                </TouchableOpacity>
+              ) : contract.pdfGenerationStatus === 'PENDING' || contract.pdfGenerationStatus === 'GENERATING' ? (
+                <View style={styles.pdfStatusRow}>
+                  <ActivityIndicator size="small" color={Colors.brandHoney} />
+                  <Text style={styles.pdfStatusText}>PDF 생성 중...</Text>
+                </View>
+              ) : contract.pdfGenerationStatus === 'FAILED' ? (
+                <View>
+                  <Text style={styles.pdfErrorText}>PDF 생성에 실패했습니다.</Text>
+                  <TouchableOpacity
+                    style={[styles.pdfRegenerateButton, regenerating && styles.pdfButtonDisabled]}
+                    onPress={handleRegeneratePdf}
+                    disabled={regenerating}
+                  >
+                    <Text style={styles.pdfRegenerateText}>
+                      {regenerating ? '재생성 중...' : '다시 생성하기'}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              ) : (
+                <Text style={styles.pdfStatusText}>PDF가 아직 생성되지 않았습니다.</Text>
+              )}
+            </View>
+          ) : null}
+
           {canSign && (
             <TouchableOpacity
               style={styles.signButton}
@@ -345,6 +414,14 @@ const styles = StyleSheet.create({
   paragraph: { fontSize: 13, color: Colors.mutedForeground, lineHeight: 20, marginBottom: 4 },
   signButton: { marginTop: 20, backgroundColor: Colors.brandInk, paddingVertical: 14, borderRadius: 12, alignItems: 'center' },
   signButtonText: { color: 'white', fontWeight: 'bold', fontSize: 15 },
+  pdfButton: { backgroundColor: Colors.brandHoney, paddingVertical: 12, borderRadius: 10, alignItems: 'center', minHeight: 44, justifyContent: 'center' },
+  pdfButtonDisabled: { opacity: 0.6 },
+  pdfButtonText: { color: Colors.brandInk, fontWeight: '700', fontSize: 14 },
+  pdfStatusRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  pdfStatusText: { fontSize: 13, color: Colors.mutedForeground },
+  pdfErrorText: { fontSize: 13, color: Colors.colorError, marginBottom: 8 },
+  pdfRegenerateButton: { backgroundColor: Colors.surfaceSoft, paddingVertical: 10, borderRadius: 10, alignItems: 'center', borderWidth: 1, borderColor: Colors.brandInk },
+  pdfRegenerateText: { fontSize: 13, color: Colors.brandInk, fontWeight: '600' },
 
   modalOverlay: { flex: 1, backgroundColor: 'rgba(37,27,16,0.5)', justifyContent: 'center', padding: 24 },
   modalBox: { backgroundColor: 'white', borderRadius: 16, padding: 24, ...Shadows.card },


### PR DESCRIPTION
## Summary
- `PdfGenerationStatus` 타입 및 `ApiContract.pdfGenerationStatus` 필드 추가
- `httpClient.downloadContractFinalPdf()` — PDF 다운로드 후 임시 파일 URI 반환
- `httpClient.regenerateContractFinalPdf()` — PDF 재생성 요청
- `DocContractDetailScreen`: `FULLY_SIGNED` 계약에서 PDF 상태별 UI
  - `READY` → PDF 열람 버튼 (시스템 PDF 뷰어)
  - `PENDING` / `GENERATING` → 생성 중 스피너
  - `FAILED` → 오류 안내 + 다시 생성하기 버튼

## Test plan
- [ ] FULLY_SIGNED 계약 상세 진입 → PDF 섹션 표시 확인
- [ ] pdfGenerationStatus=READY → 열람 버튼 → PDF 뷰어 오픈
- [ ] pdfGenerationStatus=FAILED → 재생성 버튼 → Alert 표시
- [ ] pdfGenerationStatus=GENERATING → 스피너 표시

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)