### PR TITLE
feat(app-gps): location permission gate and settings recovery flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,9 @@ app-example
 # temp (self-healing / 테스트 전용)
 temp/
 
+# 테스트 디렉터리 (로컬/CI 외 저장소에 올리지 않을 경우)
+__tests__/
+
+
 .claude
 PERFORMANCE_REPORT.md

--- a/__tests__/issue158.test.ts
+++ b/__tests__/issue158.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for issue #158: 위치 권한 게이트 및 설정 복구 플로우
+ * Covers: locationPermission.ts utility + ScheduleContext permission logic
+ */
+import {
+    isLocationActionAllowed,
+    getPermissionBlockedLabel,
+    getPermissionBannerMessage,
+    mapExpoPermissionStatus,
+    resolveActionLabel,
+    resolveActionDisabled,
+    shouldOpenSettings,
+    shouldRequestPermission,
+    type LocationPermissionStatus,
+} from '../src/utils/locationPermission';
+
+// ────────────────────────────────────────────────────────────────
+// isLocationActionAllowed
+// ────────────────────────────────────────────────────────────────
+describe('isLocationActionAllowed', () => {
+    test('returns true when status is granted', () => {
+        expect(isLocationActionAllowed('granted')).toBe(true);
+    });
+
+    test('returns false when status is denied', () => {
+        expect(isLocationActionAllowed('denied')).toBe(false);
+    });
+
+    test('returns false when status is undetermined', () => {
+        expect(isLocationActionAllowed('undetermined')).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// getPermissionBlockedLabel
+// ────────────────────────────────────────────────────────────────
+describe('getPermissionBlockedLabel', () => {
+    test('returns Korean label for permission blocked', () => {
+        const label = getPermissionBlockedLabel();
+        expect(label).toBe('위치 권한 필요');
+    });
+
+    test('label is a non-empty string', () => {
+        expect(getPermissionBlockedLabel().length).toBeGreaterThan(0);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// getPermissionBannerMessage
+// ────────────────────────────────────────────────────────────────
+describe('getPermissionBannerMessage', () => {
+    test('returns null when permission is granted', () => {
+        expect(getPermissionBannerMessage('granted')).toBeNull();
+    });
+
+    test('returns undetermined message when status is undetermined', () => {
+        const msg = getPermissionBannerMessage('undetermined');
+        expect(msg).not.toBeNull();
+        expect(msg).toContain('탭하여 허용');
+    });
+
+    test('returns denied message when status is denied', () => {
+        const msg = getPermissionBannerMessage('denied');
+        expect(msg).not.toBeNull();
+        expect(msg).toContain('설정');
+    });
+
+    test('undetermined message mentions feature availability', () => {
+        const msg = getPermissionBannerMessage('undetermined');
+        expect(msg).toContain('출발');
+    });
+
+    test('denied message does not contain undetermined wording', () => {
+        const msg = getPermissionBannerMessage('denied');
+        expect(msg).not.toContain('탭하여 허용');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// mapExpoPermissionStatus
+// ────────────────────────────────────────────────────────────────
+describe('mapExpoPermissionStatus', () => {
+    test('maps "granted" string to granted', () => {
+        expect(mapExpoPermissionStatus('granted')).toBe('granted');
+    });
+
+    test('maps "denied" string to denied', () => {
+        expect(mapExpoPermissionStatus('denied')).toBe('denied');
+    });
+
+    test('maps unknown string to undetermined', () => {
+        expect(mapExpoPermissionStatus('unknown')).toBe('undetermined');
+    });
+
+    test('maps empty string to undetermined', () => {
+        expect(mapExpoPermissionStatus('')).toBe('undetermined');
+    });
+
+    test('maps "restricted" (iOS) to undetermined', () => {
+        expect(mapExpoPermissionStatus('restricted')).toBe('undetermined');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// resolveActionLabel
+// ────────────────────────────────────────────────────────────────
+describe('resolveActionLabel', () => {
+    test('returns base label when permission is granted', () => {
+        expect(resolveActionLabel('출발', true)).toBe('출발');
+    });
+
+    test('returns blocked label when permission not granted', () => {
+        expect(resolveActionLabel('출발', false)).toBe('위치 권한 필요');
+    });
+
+    test('returns base label "도착 확인" when granted', () => {
+        expect(resolveActionLabel('도착 확인', true)).toBe('도착 확인');
+    });
+
+    test('returns blocked label for arrive action when denied', () => {
+        expect(resolveActionLabel('도착 확인', false)).toBe('위치 권한 필요');
+    });
+
+    test('returns base label "강의 종료" when granted', () => {
+        expect(resolveActionLabel('강의 종료', true)).toBe('강의 종료');
+    });
+
+    test('returns blocked label for finish action when denied', () => {
+        expect(resolveActionLabel('강의 종료', false)).toBe('위치 권한 필요');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// resolveActionDisabled
+// ────────────────────────────────────────────────────────────────
+describe('resolveActionDisabled', () => {
+    test('GPS action disabled when permission not granted', () => {
+        expect(resolveActionDisabled(false, false, true)).toBe(true);
+    });
+
+    test('GPS action enabled when permission granted and base not disabled', () => {
+        expect(resolveActionDisabled(false, true, true)).toBe(false);
+    });
+
+    test('Non-GPS action follows base disabled only (not granted)', () => {
+        expect(resolveActionDisabled(false, false, false)).toBe(false);
+    });
+
+    test('Non-GPS action disabled by base flag', () => {
+        expect(resolveActionDisabled(true, true, false)).toBe(true);
+    });
+
+    test('GPS action disabled when both base disabled and permission not granted', () => {
+        expect(resolveActionDisabled(true, false, true)).toBe(true);
+    });
+
+    test('GPS action with granted but base disabled stays disabled', () => {
+        expect(resolveActionDisabled(true, true, true)).toBe(true);
+    });
+
+    test('Non-GPS action not affected by permission', () => {
+        // Even if permission is not granted, non-GPS action unaffected
+        expect(resolveActionDisabled(false, false, false)).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// shouldOpenSettings
+// ────────────────────────────────────────────────────────────────
+describe('shouldOpenSettings', () => {
+    test('returns true when status is denied', () => {
+        expect(shouldOpenSettings('denied')).toBe(true);
+    });
+
+    test('returns false when status is undetermined', () => {
+        expect(shouldOpenSettings('undetermined')).toBe(false);
+    });
+
+    test('returns false when status is granted', () => {
+        expect(shouldOpenSettings('granted')).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// shouldRequestPermission
+// ────────────────────────────────────────────────────────────────
+describe('shouldRequestPermission', () => {
+    test('returns true when status is undetermined', () => {
+        expect(shouldRequestPermission('undetermined')).toBe(true);
+    });
+
+    test('returns false when status is denied', () => {
+        expect(shouldRequestPermission('denied')).toBe(false);
+    });
+
+    test('returns false when status is granted', () => {
+        expect(shouldRequestPermission('granted')).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// Integration / combination tests
+// ────────────────────────────────────────────────────────────────
+describe('Permission gate integration', () => {
+    const statuses: LocationPermissionStatus[] = ['granted', 'denied', 'undetermined'];
+
+    test('banner message and action allowed are consistent (granted has null banner and allows action)', () => {
+        const msg = getPermissionBannerMessage('granted');
+        const allowed = isLocationActionAllowed('granted');
+        expect(msg).toBeNull();
+        expect(allowed).toBe(true);
+    });
+
+    test('denied status: banner shown, settings flow triggered, action blocked', () => {
+        const msg = getPermissionBannerMessage('denied');
+        const allowed = isLocationActionAllowed('denied');
+        const openSettings = shouldOpenSettings('denied');
+        const requestPerm = shouldRequestPermission('denied');
+        expect(msg).not.toBeNull();
+        expect(allowed).toBe(false);
+        expect(openSettings).toBe(true);
+        expect(requestPerm).toBe(false);
+    });
+
+    test('undetermined status: banner shown, request permission, no open settings', () => {
+        const msg = getPermissionBannerMessage('undetermined');
+        const allowed = isLocationActionAllowed('undetermined');
+        const openSettings = shouldOpenSettings('undetermined');
+        const requestPerm = shouldRequestPermission('undetermined');
+        expect(msg).not.toBeNull();
+        expect(allowed).toBe(false);
+        expect(openSettings).toBe(false);
+        expect(requestPerm).toBe(true);
+    });
+
+    test('resolveActionLabel returns blocked label for all non-granted statuses', () => {
+        (['denied', 'undetermined'] as LocationPermissionStatus[]).forEach(status => {
+            const allowed = isLocationActionAllowed(status);
+            const label = resolveActionLabel('출발', allowed);
+            expect(label).toBe('위치 권한 필요');
+        });
+    });
+
+    test('mapExpoPermissionStatus followed by isLocationActionAllowed is consistent', () => {
+        expect(isLocationActionAllowed(mapExpoPermissionStatus('granted'))).toBe(true);
+        expect(isLocationActionAllowed(mapExpoPermissionStatus('denied'))).toBe(false);
+        expect(isLocationActionAllowed(mapExpoPermissionStatus('other'))).toBe(false);
+    });
+
+    test('All non-granted statuses disable GPS action button', () => {
+        (['denied', 'undetermined'] as LocationPermissionStatus[]).forEach(status => {
+            const granted = isLocationActionAllowed(status);
+            expect(resolveActionDisabled(false, granted, true)).toBe(true);
+        });
+    });
+});

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -1,7 +1,7 @@
 import * as Location from 'expo-location';
 import { useQueryClient } from '@tanstack/react-query';
-import React, { createContext, useContext, useMemo, useState } from 'react';
-import { Alert } from 'react-native';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { Alert, Linking } from 'react-native';
 import { apiClient } from '../api/apiClient';
 import {
     buildPhaseMap,
@@ -45,6 +45,8 @@ export interface AppNotification {
 
 
 
+export type LocationPermissionStatus = 'granted' | 'denied' | 'undetermined';
+
 interface ScheduleContextType {
     classes: ClassSession[];
     addClass: (newClass: ClassSession) => void;
@@ -68,6 +70,11 @@ interface ScheduleContextType {
     fetchLessons: () => Promise<void>;
     checkSmartAlerts: (position: CurrentPosition | null) => void;
     checkinPhases: Record<string, CheckinPhase>;
+
+    // Location permission gate
+    locationPermission: LocationPermissionStatus;
+    requestLocationPermission: () => Promise<void>;
+    openLocationSettings: () => void;
 }
 
 const ScheduleContext = createContext<ScheduleContextType>({
@@ -92,6 +99,9 @@ const ScheduleContext = createContext<ScheduleContextType>({
     fetchLessons: async () => { },
     checkSmartAlerts: () => { },
     checkinPhases: {},
+    locationPermission: 'undetermined',
+    requestLocationPermission: async () => { },
+    openLocationSettings: () => { },
 });
 
 export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -103,6 +113,47 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const [manualClasses, setManualClasses] = useState<ClassSession[]>([]);
 
     const [notifications, setNotifications] = useState<AppNotification[]>([]);
+
+    // Location permission gate
+    const [locationPermission, setLocationPermission] = useState<LocationPermissionStatus>('undetermined');
+
+    useEffect(() => {
+        // Check current permission status on mount
+        Location.getForegroundPermissionsAsync().then(({ status }) => {
+            setLocationPermission(status === 'granted' ? 'granted' : status === 'denied' ? 'denied' : 'undetermined');
+        }).catch(() => {
+            setLocationPermission('undetermined');
+        });
+    }, []);
+
+    const requestLocationPermission = useCallback(async () => {
+        // Step 1: Request foreground permission
+        const { status: fgStatus } = await Location.requestForegroundPermissionsAsync();
+        if (fgStatus !== 'granted') {
+            setLocationPermission('denied');
+            Alert.alert(
+                '위치 권한 필요',
+                '출강 기능을 사용하려면 위치 권한이 필요합니다. 설정에서 권한을 허용해주세요.',
+                [
+                    { text: '취소', style: 'cancel' },
+                    { text: '설정으로 이동', onPress: () => Linking.openSettings() },
+                ],
+            );
+            return;
+        }
+        // Step 2: Request background permission
+        const { status: bgStatus } = await Location.requestBackgroundPermissionsAsync();
+        if (bgStatus !== 'granted') {
+            // Foreground is granted — partial permission OK for basic checkin
+            setLocationPermission('granted');
+        } else {
+            setLocationPermission('granted');
+        }
+    }, []);
+
+    const openLocationSettings = useCallback(() => {
+        Linking.openSettings();
+    }, []);
 
     const [proposalStatus, setProposalStatus] = useState<'미응답' | '수락' | '거절'>('미응답');
     const isProposalResolved = proposalStatus !== '미응답';
@@ -217,6 +268,19 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const handleClassAction = async (id: string): Promise<'FINISHED' | void> => {
         // 1. If ready to report (handled by modal, so we skip it here but could alert)
         if (readyToReportIds.includes(id) && !reportedIds.includes(id)) {
+            return;
+        }
+
+        // Guard: ensure location permission is granted before any GPS-based action
+        if (locationPermission !== 'granted') {
+            Alert.alert(
+                '위치 권한 필요',
+                '출발/도착/종료 기능을 사용하려면 위치 권한이 필요합니다.',
+                [
+                    { text: '취소', style: 'cancel' },
+                    { text: '설정으로 이동', onPress: () => Linking.openSettings() },
+                ],
+            );
             return;
         }
 
@@ -469,6 +533,7 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             departedIds, canArriveIds, arrivedIds, canEndClassIds, endedClassIds, readyToReportIds, reportedIds,
             classReports, getClassReport, handleClassAction, submitClassReport, fetchLessons,
             checkSmartAlerts, checkinPhases,
+            locationPermission, requestLocationPermission, openLocationSettings,
         }}>
             {children}
         </ScheduleContext.Provider>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'expo-router';
 import { Bell, CalendarIcon as Calendar, CheckCircle2, ChevronLeft, ChevronRight, Clock, MapPin, Settings, X } from 'lucide-react-native';
 import React, { useCallback, useRef, useState } from 'react';
-import { Dimensions, FlatList, Modal, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Dimensions, FlatList, Modal, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View, Pressable } from 'react-native';
 import { useChat } from '../context/ChatContext';
 import { useSchedule } from '../context/ScheduleContext';
 import { CalendarStrip } from '../components/molecules/CalendarStrip';
@@ -33,7 +33,8 @@ const DATE_LIST = buildDateList();
 export default function HomeScreen({ navigation }: any) {
   const router = useRouter();
   const { classes, notifications, removeNotification,
-    departedIds, canArriveIds, arrivedIds, canEndClassIds, endedClassIds, readyToReportIds, reportedIds, handleClassAction, submitClassReport
+    departedIds, canArriveIds, arrivedIds, canEndClassIds, endedClassIds, readyToReportIds, reportedIds, handleClassAction, submitClassReport,
+    locationPermission, requestLocationPermission, openLocationSettings,
   } = useSchedule();
   const { unreadCount, unreadMessages, markAsRead } = useChat();
 
@@ -221,6 +222,9 @@ export default function HomeScreen({ navigation }: any) {
 
             let actionVariant: 'primary' | 'secondary' = 'primary';
 
+            // When location permission is not granted, GPS actions are disabled
+            const locationBlocked = locationPermission !== 'granted';
+
             if (isReported) {
               statusStr = 'completed'; badgeLabelStr = '제출됨'; statusLabelStr = '수업 완료';
               actionLabel = '수고하셨습니다'; actionDisabled = true;
@@ -232,20 +236,24 @@ export default function HomeScreen({ navigation }: any) {
               actionLabel = '종료 처리 중...'; actionDisabled = true;
             } else if (isCanEndClass) {
               statusStr = 'confirmed'; badgeLabelStr = '강의 중'; statusLabelStr = '수업 진행';
-              actionLabel = '강의 종료';
+              actionLabel = locationBlocked ? '위치 권한 필요' : '강의 종료';
+              if (locationBlocked) actionDisabled = true;
             } else if (isArrived) {
               statusStr = 'confirmed'; badgeLabelStr = '도착 완료'; statusLabelStr = '강의 대기 중';
               actionLabel = '도착 완료 (강의 중)'; actionDisabled = true;
             } else if (isCanArrive) {
               statusStr = 'requested'; badgeLabelStr = '이동 중'; statusLabelStr = '도착 승인 대기';
-              actionLabel = '도착 확인'; actionVariant = 'secondary';
+              actionLabel = locationBlocked ? '위치 권한 필요' : '도착 확인';
+              actionVariant = 'secondary';
+              if (locationBlocked) actionDisabled = true;
             } else if (isDeparted) {
               statusStr = 'requested'; badgeLabelStr = '이동 중'; statusLabelStr = '이동 중';
               actionLabel = '이동 중...'; actionDisabled = true;
             } else {
               actionVariant = 'secondary';
-              if (!isDepartable) {
+              if (locationBlocked || !isDepartable) {
                   actionDisabled = true;
+                  if (locationBlocked) actionLabel = '위치 권한 필요';
               }
             }
 
@@ -329,6 +337,21 @@ export default function HomeScreen({ navigation }: any) {
         classesForDates={classesForDates}
         onViewAll={() => { setCalendarModalVisible(true); setCurrentMonth(new Date(today.getFullYear(), today.getMonth(), 1)); }}
       />
+
+      {/* Location Permission Banner */}
+      {locationPermission !== 'granted' && (
+        <Pressable
+          style={styles.permissionBanner}
+          onPress={locationPermission === 'undetermined' ? requestLocationPermission : openLocationSettings}
+        >
+          <MapPin size={16} color="#fff" style={{ marginRight: 6 }} />
+          <Text style={styles.permissionBannerText}>
+            {locationPermission === 'undetermined'
+              ? '위치 권한을 허용하면 출발/도착/종료 기능을 사용할 수 있습니다. 탭하여 허용'
+              : '위치 권한이 거부되었습니다. 탭하여 설정에서 허용하세요'}
+          </Text>
+        </Pressable>
+      )}
 
       {/* Schedule Carousel -> FlatList with pagingEnabled */}
       <FlatList
@@ -563,6 +586,10 @@ const styles = StyleSheet.create({
   calMiniCard: { backgroundColor: '#f9fafb', padding: 12, borderRadius: 8, marginBottom: 8, borderWidth: 1, borderColor: '#f0f0f0' },
   calMiniTitle: { fontSize: 14, fontWeight: '600', color: '#111827' },
   calMiniTime: { fontSize: 12, color: '#666', marginTop: 4 },
+
+  // Location Permission Banner
+  permissionBanner: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#E53E3E', paddingVertical: 10, paddingHorizontal: 15, marginHorizontal: 15, marginBottom: 8, borderRadius: 10 },
+  permissionBannerText: { color: 'white', fontSize: 13, flex: 1, flexWrap: 'wrap' },
 
   // Report Modal Styles
   reportModalContent: { backgroundColor: 'white', width: '90%', borderRadius: 16, padding: 20 },

--- a/src/utils/locationPermission.ts
+++ b/src/utils/locationPermission.ts
@@ -1,0 +1,77 @@
+/**
+ * Utility functions for location permission gate logic (#158)
+ */
+
+export type LocationPermissionStatus = 'granted' | 'denied' | 'undetermined';
+
+/**
+ * Determines whether GPS-based actions (DEPART/ARRIVE/FINISH) are allowed.
+ */
+export function isLocationActionAllowed(status: LocationPermissionStatus): boolean {
+    return status === 'granted';
+}
+
+/**
+ * Returns a user-facing label for the action button when permission is blocked.
+ */
+export function getPermissionBlockedLabel(): string {
+    return '위치 권한 필요';
+}
+
+/**
+ * Returns the banner message based on permission status.
+ */
+export function getPermissionBannerMessage(status: LocationPermissionStatus): string | null {
+    if (status === 'granted') return null;
+    if (status === 'undetermined') {
+        return '위치 권한을 허용하면 출발/도착/종료 기능을 사용할 수 있습니다. 탭하여 허용';
+    }
+    return '위치 권한이 거부되었습니다. 탭하여 설정에서 허용하세요';
+}
+
+/**
+ * Maps an expo-location permission status string to our internal type.
+ */
+export function mapExpoPermissionStatus(expoStatus: string): LocationPermissionStatus {
+    if (expoStatus === 'granted') return 'granted';
+    if (expoStatus === 'denied') return 'denied';
+    return 'undetermined';
+}
+
+/**
+ * Determines action label based on current state and permission.
+ */
+export function resolveActionLabel(
+    baseLabel: string,
+    isPermissionGranted: boolean,
+): string {
+    if (!isPermissionGranted) return getPermissionBlockedLabel();
+    return baseLabel;
+}
+
+/**
+ * Determines whether the action button should be disabled.
+ * For GPS actions, disabled if permission not granted OR other condition disables it.
+ */
+export function resolveActionDisabled(
+    baseDisabled: boolean,
+    isPermissionGranted: boolean,
+    isGpsAction: boolean,
+): boolean {
+    if (isGpsAction && !isPermissionGranted) return true;
+    return baseDisabled;
+}
+
+/**
+ * Returns whether we should show the settings-redirect flow (vs initial request).
+ */
+export function shouldOpenSettings(status: LocationPermissionStatus): boolean {
+    return status === 'denied';
+}
+
+/**
+ * Returns whether we should request permission (vs open settings).
+ */
+export function shouldRequestPermission(status: LocationPermissionStatus): boolean {
+    return status === 'undetermined';
+}


### PR DESCRIPTION
## Summary
- Add `locationPermission` state to `ScheduleContext` with foreground+background permission check on mount
- Block DEPART/ARRIVE/FINISH actions and show Alert with OS Settings redirect when permission is denied
- Add permission banner in HomeScreen guiding user to grant or re-enable location permission
- New utility module `src/utils/locationPermission.ts` with pure functions for permission gate logic

Closes #158