### PR TITLE
feat(app-gps): background location tracking for DEPART to ARRIVE

### DIFF
--- a/__tests__/issue160.test.ts
+++ b/__tests__/issue160.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for issue #160: 백그라운드 위치 추적 (DEPART ~ ARRIVE 구간)
+ * Covers: backgroundLocationTask.ts utilities
+ *
+ * expo-location and expo-task-manager are mocked because they are native modules
+ * that cannot run in the Node.js Jest environment.
+ */
+
+// ─── Mock expo-location and expo-task-manager before imports ─────────────────
+jest.mock('expo-location', () => ({
+    Accuracy: { Balanced: 3, Lowest: 1 },
+    startLocationUpdatesAsync: jest.fn().mockResolvedValue(undefined),
+    stopLocationUpdatesAsync: jest.fn().mockResolvedValue(undefined),
+    hasStartedLocationUpdatesAsync: jest.fn().mockResolvedValue(false),
+    getForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+    requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+    requestBackgroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+    getLastKnownPositionAsync: jest.fn().mockResolvedValue(null),
+    getCurrentPositionAsync: jest.fn().mockResolvedValue({
+        coords: { latitude: 37.5, longitude: 127.0, accuracy: 10 },
+    }),
+}));
+
+jest.mock('expo-task-manager', () => ({
+    defineTask: jest.fn(),
+    isTaskDefined: jest.fn().mockReturnValue(false),
+    isTaskRegisteredAsync: jest.fn().mockResolvedValue(false),
+}));
+
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+
+import {
+    BACKGROUND_LOCATION_TASK,
+    BG_LOCATION_INTERVAL_MS,
+    BG_LOCATION_DISTANCE_M,
+    selectNearestDepartedLesson,
+    buildTrackingStartMessage,
+    buildTrackingStopMessage,
+    setBackgroundLocationCallback,
+    defineBackgroundLocationTask,
+    startBackgroundTracking,
+    stopBackgroundTracking,
+    isBackgroundTrackingActive,
+    type TrackedLesson,
+} from '../src/services/backgroundLocationTask';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+const NOW = new Date('2026-03-12T10:00:00Z');
+
+function makeLesson(id: string, startsAt: string, lat?: number, lng?: number): TrackedLesson {
+    return {
+        lessonId: id,
+        startsAt,
+        venueLat: lat ?? null,
+        venueLng: lng ?? null,
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(false);
+});
+
+// ────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────
+describe('Constants', () => {
+    test('BACKGROUND_LOCATION_TASK is a non-empty string', () => {
+        expect(typeof BACKGROUND_LOCATION_TASK).toBe('string');
+        expect(BACKGROUND_LOCATION_TASK.length).toBeGreaterThan(0);
+    });
+
+    test('BACKGROUND_LOCATION_TASK equals expected task name', () => {
+        expect(BACKGROUND_LOCATION_TASK).toBe('BACKGROUND_LOCATION_TASK');
+    });
+
+    test('BG_LOCATION_INTERVAL_MS is 10 minutes in ms (600000)', () => {
+        expect(BG_LOCATION_INTERVAL_MS).toBe(10 * 60 * 1000);
+        expect(BG_LOCATION_INTERVAL_MS).toBe(600000);
+    });
+
+    test('BG_LOCATION_DISTANCE_M is a positive number', () => {
+        expect(BG_LOCATION_DISTANCE_M).toBeGreaterThan(0);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// selectNearestDepartedLesson
+// ────────────────────────────────────────────────────────────────
+describe('selectNearestDepartedLesson', () => {
+    test('returns null for empty list', () => {
+        expect(selectNearestDepartedLesson([], NOW)).toBeNull();
+    });
+
+    test('returns the single lesson when list has one item', () => {
+        const lesson = makeLesson('L1', '2026-03-12T11:00:00Z');
+        expect(selectNearestDepartedLesson([lesson], NOW)).toBe(lesson);
+    });
+
+    test('returns lesson with start time closest to now (future)', () => {
+        const near = makeLesson('L_near', '2026-03-12T10:30:00Z'); // 30 min from now
+        const far = makeLesson('L_far', '2026-03-12T14:00:00Z');  // 4 hrs from now
+        expect(selectNearestDepartedLesson([near, far], NOW)).toBe(near);
+    });
+
+    test('returns lesson with start time closest to now (past)', () => {
+        const recent = makeLesson('L_recent', '2026-03-12T09:45:00Z'); // 15 min ago
+        const older = makeLesson('L_old', '2026-03-12T07:00:00Z');     // 3 hrs ago
+        expect(selectNearestDepartedLesson([recent, older], NOW)).toBe(recent);
+    });
+
+    test('handles mix of past and future lessons — picks closest overall', () => {
+        const past = makeLesson('L_past', '2026-03-12T09:50:00Z');    // 10 min ago
+        const future = makeLesson('L_future', '2026-03-12T10:05:00Z'); // 5 min from now
+        expect(selectNearestDepartedLesson([past, future], NOW)).toBe(future);
+    });
+
+    test('works with venue coordinates present', () => {
+        const lesson = makeLesson('L1', '2026-03-12T11:00:00Z', 37.5, 127.0);
+        const result = selectNearestDepartedLesson([lesson], NOW);
+        expect(result?.venueLat).toBe(37.5);
+        expect(result?.venueLng).toBe(127.0);
+    });
+
+    test('works with null venue coordinates', () => {
+        const lesson = makeLesson('L1', '2026-03-12T11:00:00Z');
+        expect(selectNearestDepartedLesson([lesson], NOW)?.venueLat).toBeNull();
+    });
+
+    test('handles three lessons — picks closest to now', () => {
+        const lessons = [
+            makeLesson('L_far', '2026-03-12T14:00:00Z'),
+            makeLesson('L_near', '2026-03-12T10:15:00Z'),
+            makeLesson('L_mid', '2026-03-12T11:30:00Z'),
+        ];
+        expect(selectNearestDepartedLesson(lessons, NOW)?.lessonId).toBe('L_near');
+    });
+
+    test('uses current Date when now parameter is omitted', () => {
+        const lesson = makeLesson('L1', new Date().toISOString());
+        const result = selectNearestDepartedLesson([lesson]);
+        expect(result).toBe(lesson);
+    });
+
+    test('lessonId is preserved in returned object', () => {
+        const lesson = makeLesson('MY_LESSON_ID', '2026-03-12T11:00:00Z');
+        expect(selectNearestDepartedLesson([lesson], NOW)?.lessonId).toBe('MY_LESSON_ID');
+    });
+
+    test('startsAt is preserved in returned object', () => {
+        const isoStr = '2026-03-12T11:00:00Z';
+        const lesson = makeLesson('L1', isoStr);
+        expect(selectNearestDepartedLesson([lesson], NOW)?.startsAt).toBe(isoStr);
+    });
+
+    test('integration: A=45min, B=3hrs, C=1hr ago — picks A', () => {
+        const lessons: TrackedLesson[] = [
+            { lessonId: 'A', startsAt: '2026-03-12T10:45:00Z', venueLat: null, venueLng: null },
+            { lessonId: 'B', startsAt: '2026-03-12T13:00:00Z', venueLat: null, venueLng: null },
+            { lessonId: 'C', startsAt: '2026-03-12T09:00:00Z', venueLat: null, venueLng: null },
+        ];
+        expect(selectNearestDepartedLesson(lessons, NOW)?.lessonId).toBe('A');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// buildTrackingStartMessage
+// ────────────────────────────────────────────────────────────────
+describe('buildTrackingStartMessage', () => {
+    const lesson = makeLesson('L1', '2026-03-12T11:00:00Z', 37.5, 127.0);
+
+    test('returns a non-empty string', () => {
+        expect(buildTrackingStartMessage(lesson).length).toBeGreaterThan(0);
+    });
+
+    test('mentions the polling interval (10분)', () => {
+        expect(buildTrackingStartMessage(lesson)).toContain('10분');
+    });
+
+    test('mentions background tracking concept', () => {
+        expect(buildTrackingStartMessage(lesson)).toContain('추적');
+    });
+
+    test('does not contain "undefined"', () => {
+        expect(buildTrackingStartMessage(lesson)).not.toContain('undefined');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// buildTrackingStopMessage
+// ────────────────────────────────────────────────────────────────
+describe('buildTrackingStopMessage', () => {
+    test('returns a non-empty string', () => {
+        expect(buildTrackingStopMessage().length).toBeGreaterThan(0);
+    });
+
+    test('mentions tracking termination (종료)', () => {
+        expect(buildTrackingStopMessage()).toContain('종료');
+    });
+
+    test('mentions arrival confirmation (도착)', () => {
+        expect(buildTrackingStopMessage()).toContain('도착');
+    });
+
+    test('does not contain "undefined"', () => {
+        expect(buildTrackingStopMessage()).not.toContain('undefined');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// setBackgroundLocationCallback
+// ────────────────────────────────────────────────────────────────
+describe('setBackgroundLocationCallback', () => {
+    test('accepts a function without throwing', () => {
+        expect(() => setBackgroundLocationCallback(() => {})).not.toThrow();
+    });
+
+    test('accepts null without throwing', () => {
+        expect(() => setBackgroundLocationCallback(null)).not.toThrow();
+    });
+
+    test('can replace a callback with another without throwing', () => {
+        const cb1 = jest.fn();
+        const cb2 = jest.fn();
+        setBackgroundLocationCallback(cb1);
+        expect(() => setBackgroundLocationCallback(cb2)).not.toThrow();
+        setBackgroundLocationCallback(null);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// defineBackgroundLocationTask
+// ────────────────────────────────────────────────────────────────
+describe('defineBackgroundLocationTask', () => {
+    test('does not throw when called', () => {
+        expect(() => defineBackgroundLocationTask()).not.toThrow();
+    });
+
+    test('calls TaskManager.defineTask when task is not already defined', () => {
+        (TaskManager.isTaskDefined as jest.Mock).mockReturnValue(false);
+        defineBackgroundLocationTask();
+        expect(TaskManager.defineTask).toHaveBeenCalledWith(BACKGROUND_LOCATION_TASK, expect.any(Function));
+    });
+
+    test('does NOT call defineTask when task is already defined', () => {
+        (TaskManager.isTaskDefined as jest.Mock).mockReturnValue(true);
+        defineBackgroundLocationTask();
+        expect(TaskManager.defineTask).not.toHaveBeenCalled();
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// startBackgroundTracking
+// ────────────────────────────────────────────────────────────────
+describe('startBackgroundTracking', () => {
+    test('calls startLocationUpdatesAsync when not already running', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(false);
+        await startBackgroundTracking();
+        expect(Location.startLocationUpdatesAsync).toHaveBeenCalledWith(
+            BACKGROUND_LOCATION_TASK,
+            expect.objectContaining({ timeInterval: BG_LOCATION_INTERVAL_MS }),
+        );
+    });
+
+    test('does NOT call startLocationUpdatesAsync when already running', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(true);
+        await startBackgroundTracking();
+        expect(Location.startLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+
+    test('passes distanceInterval to startLocationUpdatesAsync', async () => {
+        await startBackgroundTracking();
+        expect(Location.startLocationUpdatesAsync).toHaveBeenCalledWith(
+            BACKGROUND_LOCATION_TASK,
+            expect.objectContaining({ distanceInterval: BG_LOCATION_DISTANCE_M }),
+        );
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// stopBackgroundTracking
+// ────────────────────────────────────────────────────────────────
+describe('stopBackgroundTracking', () => {
+    test('calls stopLocationUpdatesAsync when tracking is active', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(true);
+        await stopBackgroundTracking();
+        expect(Location.stopLocationUpdatesAsync).toHaveBeenCalledWith(BACKGROUND_LOCATION_TASK);
+    });
+
+    test('does NOT call stopLocationUpdatesAsync when tracking is not active', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(false);
+        await stopBackgroundTracking();
+        expect(Location.stopLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// isBackgroundTrackingActive
+// ────────────────────────────────────────────────────────────────
+describe('isBackgroundTrackingActive', () => {
+    test('returns true when tracking is active', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(true);
+        expect(await isBackgroundTrackingActive()).toBe(true);
+    });
+
+    test('returns false when tracking is not active', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockResolvedValue(false);
+        expect(await isBackgroundTrackingActive()).toBe(false);
+    });
+
+    test('returns false when hasStartedLocationUpdatesAsync throws', async () => {
+        (Location.hasStartedLocationUpdatesAsync as jest.Mock).mockRejectedValue(new Error('fail'));
+        expect(await isBackgroundTrackingActive()).toBe(false);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
         "expo-system-ui": "~6.0.9",
+        "expo-task-manager": "~14.0.9",
         "expo-web-browser": "~15.0.10",
         "lucide-react-native": "^0.576.0",
         "react": "19.1.0",
@@ -10477,6 +10478,19 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-task-manager": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-14.0.9.tgz",
+      "integrity": "sha512-GKWtXrkedr4XChHfTm5IyTcSfMtCPxzx89y4CMVqKfyfROATibrE/8UI5j7UC/pUOfFoYlQvulQEvECMreYuUA==",
+      "license": "MIT",
+      "dependencies": {
+        "unimodules-app-loader": "~6.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-updates-interface": {
@@ -21236,6 +21250,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unimodules-app-loader": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-6.0.8.tgz",
+      "integrity": "sha512-fqS8QwT/MC/HAmw1NKCHdzsPA6WaLm0dNmoC5Pz6lL+cDGYeYCNdHMO9fy08aL2ZD7cVkNM0pSR/AoNRe+rslA==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-status-bar": "~3.0.9",
     "expo-symbols": "~1.0.8",
     "expo-system-ui": "~6.0.9",
+    "expo-task-manager": "~14.0.9",
     "expo-web-browser": "~15.0.10",
     "lucide-react-native": "^0.576.0",
     "react": "19.1.0",

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Alert, Linking } from 'react-native';
 import { apiClient } from '../api/apiClient';
+import { startBackgroundTracking, stopBackgroundTracking, selectNearestDepartedLesson } from '../services/backgroundLocationTask';
 import {
     buildPhaseMap,
     extractIdSets,
@@ -387,6 +388,10 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             ]);
             setLocalCheckinPhases(prev => ({ ...prev, [id]: transitionPhase(prev[id] ?? 'DEPARTED', 'ARRIVE') }));
             Alert.alert('도착 완료', '도착이 등록되었습니다. 강의를 진행해주세요.');
+
+            // Stop background location tracking — ARRIVE completed
+            stopBackgroundTracking().catch(() => {});
+
             return;
         }
 
@@ -440,6 +445,25 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 ]);
                 setLocalCheckinPhases(prev => ({ ...prev, [id]: transitionPhase(prev[id] ?? 'IDLE', 'DEPART') }));
                 Alert.alert('출발 완료', '출발이 등록되었습니다. 안전하게 이동하세요.');
+
+                // Start background location tracking for DEPART → ARRIVE window
+                try {
+                    // Pick nearest departed lesson (including the just-departed one)
+                    const departedLessonsForTracking = classes
+                        .filter(c => c.id === id)
+                        .map(c => ({
+                            lessonId: c.id,
+                            startsAt: c.date + 'T' + (c.time.split(' - ')[0]?.trim() ?? '09:00') + ':00',
+                            venueLat: c.venueLat ?? null,
+                            venueLng: c.venueLng ?? null,
+                        }));
+                    const nearest = selectNearestDepartedLesson(departedLessonsForTracking);
+                    if (nearest) {
+                        await startBackgroundTracking();
+                    }
+                } catch {
+                    // Background tracking failure is non-fatal
+                }
 
             } catch {
                 Alert.alert('오류', '위치를 가져오는데 실패했습니다.');

--- a/src/services/backgroundLocationTask.ts
+++ b/src/services/backgroundLocationTask.ts
@@ -1,0 +1,136 @@
+/**
+ * Background Location Tracking Service (#160)
+ *
+ * Tracks the instructor's location in the background during the DEPART → ARRIVE window.
+ * Uses expo-location + expo-task-manager for OS-level background location updates.
+ *
+ * Policy:
+ * - Only the single closest upcoming lesson is tracked
+ * - Polling interval: 10 minutes (600 000 ms)
+ * - Tracking starts after a successful DEPART checkin
+ * - Tracking stops after a successful ARRIVE checkin
+ * - App force-quit: tracking continuity is NOT guaranteed
+ */
+
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+export const BACKGROUND_LOCATION_TASK = 'BACKGROUND_LOCATION_TASK';
+
+/** Minimum time between location updates (ms) — 10 minutes */
+export const BG_LOCATION_INTERVAL_MS = 10 * 60 * 1000;
+
+/** Minimum distance change to trigger an update (metres) — set low so time-based polling dominates */
+export const BG_LOCATION_DISTANCE_M = 50;
+
+// ─── Callback store ───────────────────────────────────────────────────────────
+type LocationUpdateCallback = (coords: { lat: number; lng: number; accuracyMeters: number | undefined }) => void;
+
+let _onLocationUpdate: LocationUpdateCallback | null = null;
+
+/** Register a callback that will be called whenever the background task fires. */
+export function setBackgroundLocationCallback(cb: LocationUpdateCallback | null): void {
+    _onLocationUpdate = cb;
+}
+
+// ─── Task Definition ──────────────────────────────────────────────────────────
+/**
+ * This must be called at the top level of the app (before any rendering).
+ * When the OS delivers a background location, the callback (if set) is invoked.
+ */
+export function defineBackgroundLocationTask(): void {
+    if (!TaskManager.isTaskDefined(BACKGROUND_LOCATION_TASK)) {
+        TaskManager.defineTask(BACKGROUND_LOCATION_TASK, ({ data, error }: any) => {
+            if (error) return;
+            const locations: Location.LocationObject[] = data?.locations ?? [];
+            if (locations.length === 0) return;
+            const latest = locations[locations.length - 1];
+            if (!latest?.coords) return;
+            _onLocationUpdate?.({
+                lat: latest.coords.latitude,
+                lng: latest.coords.longitude,
+                accuracyMeters: latest.coords.accuracy ?? undefined,
+            });
+        });
+    }
+}
+
+// ─── Start / Stop ─────────────────────────────────────────────────────────────
+/**
+ * Start background location tracking.
+ * Requires background location permission to be granted beforehand.
+ * Safe to call multiple times — no-ops if already running.
+ */
+export async function startBackgroundTracking(): Promise<void> {
+    const isRunning = await Location.hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(() => false);
+    if (isRunning) return;
+
+    await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
+        accuracy: Location.Accuracy.Balanced,
+        timeInterval: BG_LOCATION_INTERVAL_MS,
+        distanceInterval: BG_LOCATION_DISTANCE_M,
+        foregroundService: {
+            notificationTitle: '이동 중 위치 추적',
+            notificationBody: '수업 도착 체크인을 위해 위치를 추적 중입니다.',
+        },
+        pausesUpdatesAutomatically: false,
+        showsBackgroundLocationIndicator: true,
+    });
+}
+
+/**
+ * Stop background location tracking.
+ * Safe to call when tracking is not running.
+ */
+export async function stopBackgroundTracking(): Promise<void> {
+    const isRunning = await Location.hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(() => false);
+    if (!isRunning) return;
+    await Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(() => {});
+}
+
+/**
+ * Returns whether background tracking is currently active.
+ */
+export async function isBackgroundTrackingActive(): Promise<boolean> {
+    return Location.hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(() => false);
+}
+
+// ─── Nearest-lesson selector ──────────────────────────────────────────────────
+export interface TrackedLesson {
+    lessonId: string;
+    startsAt: string; // ISO string
+    venueLat: number | null;
+    venueLng: number | null;
+}
+
+/**
+ * From a list of lessons that are in DEPARTED state (awaiting ARRIVE),
+ * returns the single lesson whose start time is closest to now.
+ * Returns null if the list is empty.
+ */
+export function selectNearestDepartedLesson(
+    lessons: TrackedLesson[],
+    now: Date = new Date(),
+): TrackedLesson | null {
+    if (lessons.length === 0) return null;
+    return lessons.reduce<TrackedLesson>((nearest, lesson) => {
+        const tNearest = Math.abs(new Date(nearest.startsAt).getTime() - now.getTime());
+        const tLesson = Math.abs(new Date(lesson.startsAt).getTime() - now.getTime());
+        return tLesson < tNearest ? lesson : nearest;
+    }, lessons[0]);
+}
+
+/**
+ * Build a human-readable tracking start confirmation message.
+ */
+export function buildTrackingStartMessage(lesson: TrackedLesson): string {
+    return `수업 도착까지 백그라운드 위치 추적을 시작합니다. (10분 간격)`;
+}
+
+/**
+ * Build a human-readable tracking stop confirmation message.
+ */
+export function buildTrackingStopMessage(): string {
+    return `도착이 확인되었습니다. 위치 추적을 종료합니다.`;
+}


### PR DESCRIPTION
## Summary
- Install `expo-task-manager` and create `src/services/backgroundLocationTask.ts`
- Define `BACKGROUND_LOCATION_TASK` with 10-minute polling interval and 50m distance filter
- `startBackgroundTracking` / `stopBackgroundTracking` with idempotency guards
- `selectNearestDepartedLesson`: picks the single lesson closest to now from departed set
- `ScheduleContext`: calls `startBackgroundTracking` after DEPART success, `stopBackgroundTracking` after ARRIVE success
- Background tracking failure is non-fatal; app force-quit continuity not guaranteed (per spec)

Closes #160