### PR TITLE
feat(app-gps): arrival/finish retry UX and suspicious guidance

### DIFF
--- a/__tests__/issue162.test.ts
+++ b/__tests__/issue162.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for issue #162: 도착/종료 실패 재시도 UX 및 suspicious 안내
+ * Covers: checkinResultUX.ts utilities
+ */
+
+import {
+    classifyCheckinResult,
+    buildCheckinResultUX,
+    describeAccuracy,
+    isLowAccuracy,
+    isOutOfRange,
+    isSuspicious,
+    buildFinishReminderMessage,
+    buildFinishReminderTitle,
+    ACCURACY_GOOD_METERS,
+    ACCURACY_ACCEPTABLE_METERS,
+    ACCURACY_SUSPICIOUS_METERS,
+    LOCATION_VALID_RADIUS_METERS,
+    type CheckinResultInfo,
+    type CheckinResultUXType,
+} from '../src/utils/checkinResultUX';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+function makeInfo(overrides: Partial<CheckinResultInfo> = {}): CheckinResultInfo {
+    return {
+        isValid: true,
+        locationStatus: 'OK',
+        distanceMeters: 100,
+        accuracyMeters: 50,
+        ...overrides,
+    };
+}
+
+// ────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────
+describe('Constants', () => {
+    test('ACCURACY_GOOD_METERS is 80', () => {
+        expect(ACCURACY_GOOD_METERS).toBe(80);
+    });
+
+    test('ACCURACY_ACCEPTABLE_METERS is 150', () => {
+        expect(ACCURACY_ACCEPTABLE_METERS).toBe(150);
+    });
+
+    test('ACCURACY_SUSPICIOUS_METERS is 300', () => {
+        expect(ACCURACY_SUSPICIOUS_METERS).toBe(300);
+    });
+
+    test('LOCATION_VALID_RADIUS_METERS is 250', () => {
+        expect(LOCATION_VALID_RADIUS_METERS).toBe(250);
+    });
+
+    test('Constants are in correct ascending order', () => {
+        expect(ACCURACY_GOOD_METERS).toBeLessThan(ACCURACY_ACCEPTABLE_METERS);
+        expect(ACCURACY_ACCEPTABLE_METERS).toBeLessThan(ACCURACY_SUSPICIOUS_METERS);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// classifyCheckinResult
+// ────────────────────────────────────────────────────────────────
+describe('classifyCheckinResult', () => {
+    test('valid + OK → SUCCESS', () => {
+        expect(classifyCheckinResult(makeInfo())).toBe('SUCCESS');
+    });
+
+    test('valid + SUSPICIOUS → SUCCESS_WITH_WARNING', () => {
+        expect(classifyCheckinResult(makeInfo({ locationStatus: 'SUSPICIOUS' }))).toBe('SUCCESS_WITH_WARNING');
+    });
+
+    test('invalid + far distance + good accuracy → OUT_OF_RANGE', () => {
+        expect(classifyCheckinResult(makeInfo({
+            isValid: false,
+            distanceMeters: 400,
+            accuracyMeters: 50,
+            locationStatus: 'OK',
+        }))).toBe('OUT_OF_RANGE');
+    });
+
+    test('invalid + low accuracy → LOW_ACCURACY', () => {
+        expect(classifyCheckinResult(makeInfo({
+            isValid: false,
+            distanceMeters: 100,
+            accuracyMeters: 200,
+            locationStatus: 'OK',
+        }))).toBe('LOW_ACCURACY');
+    });
+
+    test('invalid + SUSPICIOUS locationStatus + within range → SUSPICIOUS', () => {
+        expect(classifyCheckinResult(makeInfo({
+            isValid: false,
+            distanceMeters: 100,
+            accuracyMeters: 100,
+            locationStatus: 'SUSPICIOUS',
+        }))).toBe('SUSPICIOUS');
+    });
+
+    test('invalid + no specific condition → OUT_OF_RANGE (default)', () => {
+        expect(classifyCheckinResult(makeInfo({
+            isValid: false,
+            distanceMeters: 200,
+            accuracyMeters: 100,
+            locationStatus: 'OK',
+        }))).toBe('OUT_OF_RANGE');
+    });
+
+    test('boundary: distance exactly at LOCATION_VALID_RADIUS_METERS with good accuracy falls to default OUT_OF_RANGE', () => {
+        // distanceMeters=250 is NOT > 250, so OUT_OF_RANGE condition fails
+        // accuracyMeters=50 is NOT > 150, so LOW_ACCURACY fails
+        // locationStatus=OK so SUSPICIOUS fails
+        // default branch → OUT_OF_RANGE
+        const result = classifyCheckinResult(makeInfo({
+            isValid: false,
+            distanceMeters: LOCATION_VALID_RADIUS_METERS,
+            accuracyMeters: 50,
+            locationStatus: 'OK',
+        }));
+        expect(result).toBe('OUT_OF_RANGE');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// buildCheckinResultUX
+// ────────────────────────────────────────────────────────────────
+describe('buildCheckinResultUX', () => {
+    test('SUCCESS: canRetry=false, type=SUCCESS', () => {
+        const ux = buildCheckinResultUX(makeInfo());
+        expect(ux.type).toBe('SUCCESS');
+        expect(ux.canRetry).toBe(false);
+        expect(ux.title.length).toBeGreaterThan(0);
+        expect(ux.message.length).toBeGreaterThan(0);
+    });
+
+    test('OUT_OF_RANGE: canRetry=true, mentions distance', () => {
+        const ux = buildCheckinResultUX(makeInfo({
+            isValid: false,
+            distanceMeters: 400,
+            accuracyMeters: 50,
+            locationStatus: 'OK',
+        }));
+        expect(ux.type).toBe('OUT_OF_RANGE');
+        expect(ux.canRetry).toBe(true);
+        expect(ux.message).toContain('400');
+    });
+
+    test('LOW_ACCURACY: canRetry=true, mentions accuracy', () => {
+        const ux = buildCheckinResultUX(makeInfo({
+            isValid: false,
+            distanceMeters: 100,
+            accuracyMeters: 200,
+            locationStatus: 'OK',
+        }));
+        expect(ux.type).toBe('LOW_ACCURACY');
+        expect(ux.canRetry).toBe(true);
+        expect(ux.message).toContain('200');
+    });
+
+    test('SUSPICIOUS: canRetry=true', () => {
+        const ux = buildCheckinResultUX(makeInfo({
+            isValid: false,
+            distanceMeters: 100,
+            accuracyMeters: 100,
+            locationStatus: 'SUSPICIOUS',
+        }));
+        expect(ux.type).toBe('SUSPICIOUS');
+        expect(ux.canRetry).toBe(true);
+    });
+
+    test('SUCCESS_WITH_WARNING: canRetry=false, title not empty', () => {
+        const ux = buildCheckinResultUX(makeInfo({ locationStatus: 'SUSPICIOUS' }));
+        expect(ux.type).toBe('SUCCESS_WITH_WARNING');
+        expect(ux.canRetry).toBe(false);
+        expect(ux.title.length).toBeGreaterThan(0);
+    });
+
+    test('All UX types have non-empty title and message', () => {
+        const cases: CheckinResultInfo[] = [
+            makeInfo(),
+            makeInfo({ locationStatus: 'SUSPICIOUS' }),
+            makeInfo({ isValid: false, distanceMeters: 400, accuracyMeters: 50, locationStatus: 'OK' }),
+            makeInfo({ isValid: false, distanceMeters: 100, accuracyMeters: 200, locationStatus: 'OK' }),
+            makeInfo({ isValid: false, distanceMeters: 100, accuracyMeters: 100, locationStatus: 'SUSPICIOUS' }),
+        ];
+        cases.forEach(info => {
+            const ux = buildCheckinResultUX(info);
+            expect(ux.title.length).toBeGreaterThan(0);
+            expect(ux.message.length).toBeGreaterThan(0);
+        });
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// describeAccuracy
+// ────────────────────────────────────────────────────────────────
+describe('describeAccuracy', () => {
+    test('returns good accuracy description for values <= 80m', () => {
+        expect(describeAccuracy(50)).toContain('좋음');
+        expect(describeAccuracy(80)).toContain('좋음');
+    });
+
+    test('returns acceptable accuracy for values 81–150m', () => {
+        expect(describeAccuracy(100)).toContain('보통');
+        expect(describeAccuracy(150)).toContain('보통');
+    });
+
+    test('returns low accuracy for values 151–300m', () => {
+        expect(describeAccuracy(200)).toContain('낮음');
+        expect(describeAccuracy(300)).toContain('낮음');
+    });
+
+    test('returns very low accuracy for values > 300m', () => {
+        expect(describeAccuracy(301)).toContain('매우 낮음');
+    });
+
+    test('boundary: 80 is still "good"', () => {
+        expect(describeAccuracy(80)).toContain('좋음');
+    });
+
+    test('boundary: 81 is "보통"', () => {
+        expect(describeAccuracy(81)).toContain('보통');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// isLowAccuracy
+// ────────────────────────────────────────────────────────────────
+describe('isLowAccuracy', () => {
+    test('returns false for accuracy <= 150m', () => {
+        expect(isLowAccuracy(50)).toBe(false);
+        expect(isLowAccuracy(150)).toBe(false);
+    });
+
+    test('returns true for accuracy > 150m', () => {
+        expect(isLowAccuracy(151)).toBe(true);
+        expect(isLowAccuracy(300)).toBe(true);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// isOutOfRange
+// ────────────────────────────────────────────────────────────────
+describe('isOutOfRange', () => {
+    test('returns false for distance <= 250m', () => {
+        expect(isOutOfRange(100)).toBe(false);
+        expect(isOutOfRange(250)).toBe(false);
+    });
+
+    test('returns true for distance > 250m', () => {
+        expect(isOutOfRange(251)).toBe(true);
+        expect(isOutOfRange(500)).toBe(true);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// isSuspicious
+// ────────────────────────────────────────────────────────────────
+describe('isSuspicious', () => {
+    test('returns false when both under threshold', () => {
+        expect(isSuspicious(200, 200)).toBe(false);
+    });
+
+    test('returns true when distance exceeds 300m', () => {
+        expect(isSuspicious(301, 50)).toBe(true);
+    });
+
+    test('returns true when accuracy exceeds 300m', () => {
+        expect(isSuspicious(100, 301)).toBe(true);
+    });
+
+    test('returns true when both exceed threshold', () => {
+        expect(isSuspicious(400, 400)).toBe(true);
+    });
+
+    test('boundary: 300 is not suspicious', () => {
+        expect(isSuspicious(300, 300)).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// buildFinishReminderMessage / Title
+// ────────────────────────────────────────────────────────────────
+describe('buildFinishReminderMessage', () => {
+    test('includes lesson title', () => {
+        expect(buildFinishReminderMessage('미술 강의')).toContain('미술 강의');
+    });
+
+    test('mentions finish action', () => {
+        expect(buildFinishReminderMessage('수학 강의')).toContain('종료');
+    });
+
+    test('returns non-empty string', () => {
+        expect(buildFinishReminderMessage('강의').length).toBeGreaterThan(0);
+    });
+
+    test('does not contain undefined', () => {
+        expect(buildFinishReminderMessage('강의')).not.toContain('undefined');
+    });
+});
+
+describe('buildFinishReminderTitle', () => {
+    test('returns non-empty string', () => {
+        expect(buildFinishReminderTitle().length).toBeGreaterThan(0);
+    });
+
+    test('mentions finish/종료', () => {
+        expect(buildFinishReminderTitle()).toContain('종료');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────
+// Integration
+// ────────────────────────────────────────────────────────────────
+describe('Integration', () => {
+    test('OUT_OF_RANGE UX always has retry and specific message', () => {
+        const ux = buildCheckinResultUX(makeInfo({
+            isValid: false,
+            distanceMeters: 500,
+            accuracyMeters: 30,
+            locationStatus: 'OK',
+        }));
+        expect(ux.canRetry).toBe(true);
+        expect(ux.type).toBe('OUT_OF_RANGE');
+        expect(isOutOfRange(500)).toBe(true);
+    });
+
+    test('LOW_ACCURACY UX consistent with isLowAccuracy utility', () => {
+        const accuracyMeters = 200;
+        const ux = buildCheckinResultUX(makeInfo({
+            isValid: false,
+            distanceMeters: 100,
+            accuracyMeters,
+            locationStatus: 'OK',
+        }));
+        expect(ux.type).toBe('LOW_ACCURACY');
+        expect(isLowAccuracy(accuracyMeters)).toBe(true);
+    });
+
+    test('SUCCESS_WITH_WARNING: isSuspicious flags it but isValid=true', () => {
+        const info = makeInfo({ isValid: true, locationStatus: 'SUSPICIOUS', distanceMeters: 400, accuracyMeters: 400 });
+        const ux = buildCheckinResultUX(info);
+        expect(ux.type).toBe('SUCCESS_WITH_WARNING');
+        expect(isSuspicious(info.distanceMeters, info.accuracyMeters)).toBe(true);
+    });
+});

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 import { Alert, Linking } from 'react-native';
 import { apiClient } from '../api/apiClient';
 import { startBackgroundTracking, stopBackgroundTracking, selectNearestDepartedLesson } from '../services/backgroundLocationTask';
+import { buildCheckinResultUX } from '../utils/checkinResultUX';
 import {
     buildPhaseMap,
     extractIdSets,
@@ -308,10 +309,11 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         if (canEndClassIds.includes(id) && !endedClassIds.includes(id)) {
             const requestId = lessonRequestMap[id];
             let coords: Awaited<ReturnType<typeof getLocationForCheckin>> = null;
+            let finishResult: ApiAttendanceEvent | null = null;
             if (requestId) {
                 try {
                     coords = await getLocationForCheckin();
-                    await apiClient.checkinByAssignment(requestId, {
+                    finishResult = await apiClient.checkinByAssignment(requestId, {
                         eventType: 'FINISH',
                         idempotencyKey: `FINISH_${requestId}_${Date.now()}`,
                         lat: coords?.lat ?? 0,
@@ -325,9 +327,26 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 }
             }
 
+            // Show retry/guidance UX based on server response
+            if (finishResult) {
+                const ux = buildCheckinResultUX({
+                    isValid: finishResult.isValid,
+                    locationStatus: finishResult.locationStatus,
+                    distanceMeters: finishResult.distanceMeters,
+                    accuracyMeters: finishResult.accuracyMeters,
+                });
+                if (ux.canRetry) {
+                    Alert.alert(ux.title, ux.message);
+                    return;
+                }
+                if (ux.type === 'SUCCESS_WITH_WARNING') {
+                    Alert.alert(ux.title, ux.message);
+                }
+            }
+
             queryClient.setQueryData<ApiAttendanceEvent[]>(queryKeys.attendanceEvents, (prev = []) => [
                 ...prev,
-                {
+                finishResult ?? {
                     attendanceEventId: `optimistic-finish-${requestId ?? id}`,
                     companyId: '',
                     lessonId: id,
@@ -351,10 +370,11 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         if (canArriveIds.includes(id) && !arrivedIds.includes(id)) {
             const requestId = lessonRequestMap[id];
             let coords: Awaited<ReturnType<typeof getLocationForCheckin>> = null;
+            let arriveResult: ApiAttendanceEvent | null = null;
             if (requestId) {
                 try {
                     coords = await getLocationForCheckin();
-                    await apiClient.checkinByAssignment(requestId, {
+                    arriveResult = await apiClient.checkinByAssignment(requestId, {
                         eventType: 'ARRIVE',
                         idempotencyKey: `ARRIVE_${requestId}_${Date.now()}`,
                         lat: coords?.lat ?? 0,
@@ -368,9 +388,27 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 }
             }
 
+            // Show retry/guidance UX based on server response
+            if (arriveResult) {
+                const ux = buildCheckinResultUX({
+                    isValid: arriveResult.isValid,
+                    locationStatus: arriveResult.locationStatus,
+                    distanceMeters: arriveResult.distanceMeters,
+                    accuracyMeters: arriveResult.accuracyMeters,
+                });
+                if (ux.canRetry) {
+                    Alert.alert(ux.title, ux.message);
+                    return;
+                }
+                // Show warning even on success if suspicious
+                if (ux.type === 'SUCCESS_WITH_WARNING') {
+                    Alert.alert(ux.title, ux.message);
+                }
+            }
+
             queryClient.setQueryData<ApiAttendanceEvent[]>(queryKeys.attendanceEvents, (prev = []) => [
                 ...prev,
-                {
+                arriveResult ?? {
                     attendanceEventId: `optimistic-arrive-${requestId ?? id}`,
                     companyId: '',
                     lessonId: id,
@@ -387,7 +425,9 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 },
             ]);
             setLocalCheckinPhases(prev => ({ ...prev, [id]: transitionPhase(prev[id] ?? 'DEPARTED', 'ARRIVE') }));
-            Alert.alert('도착 완료', '도착이 등록되었습니다. 강의를 진행해주세요.');
+            if (!arriveResult || arriveResult.locationStatus !== 'SUSPICIOUS') {
+                Alert.alert('도착 완료', '도착이 등록되었습니다. 강의를 진행해주세요.');
+            }
 
             // Stop background location tracking — ARRIVE completed
             stopBackgroundTracking().catch(() => {});

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -124,6 +124,9 @@ export function setupNotificationHandlers(): () => void {
             router.replace({ pathname: '/(tabs)/docs', params: { targetTab: '계약' } } as any);
         } else if (data?.type === 'SETTLEMENT') {
             router.replace('/(tabs)/income' as any);
+        } else if (data?.type === 'FINISH_REMINDER') {
+            // Navigate to home tab where the user can tap FINISH on the relevant lesson
+            router.replace('/(tabs)/' as any);
         }
     });
 

--- a/src/utils/checkinResultUX.ts
+++ b/src/utils/checkinResultUX.ts
@@ -1,0 +1,167 @@
+/**
+ * Utility functions for arrival/finish retry UX and suspicious guidance (#162)
+ *
+ * Processes ApiAttendanceEvent responses to determine user-facing messages
+ * for retry, low accuracy, suspicious location, and finish-reminder flows.
+ */
+
+/** GPS accuracy thresholds (metres) — aligned with GPS policy doc (#157) */
+export const ACCURACY_GOOD_METERS = 80;
+export const ACCURACY_ACCEPTABLE_METERS = 150;
+export const ACCURACY_SUSPICIOUS_METERS = 300;
+
+/** Radius within which a checkin is considered valid (metres) */
+export const LOCATION_VALID_RADIUS_METERS = 250;
+
+/** LocationStatus values from the API */
+export type LocationStatus = 'OK' | 'SUSPICIOUS' | 'OUT_OF_RANGE';
+
+export interface CheckinResultInfo {
+    isValid: boolean;
+    locationStatus: string; // 'OK' | 'SUSPICIOUS' (from API)
+    distanceMeters: number;
+    accuracyMeters: number;
+}
+
+export type CheckinResultUXType =
+    | 'SUCCESS'
+    | 'OUT_OF_RANGE'
+    | 'LOW_ACCURACY'
+    | 'SUSPICIOUS'
+    | 'SUCCESS_WITH_WARNING';
+
+export interface CheckinResultUX {
+    type: CheckinResultUXType;
+    title: string;
+    message: string;
+    canRetry: boolean;
+}
+
+/**
+ * Classify a checkin result into a UX type.
+ *
+ * Priority:
+ * 1. Invalid + out-of-range → OUT_OF_RANGE (retry)
+ * 2. Invalid + low accuracy → LOW_ACCURACY (retry)
+ * 3. Valid + suspicious → SUCCESS_WITH_WARNING
+ * 4. Invalid + suspicious → SUSPICIOUS (retry)
+ * 5. Valid → SUCCESS
+ */
+export function classifyCheckinResult(info: CheckinResultInfo): CheckinResultUXType {
+    const { isValid, locationStatus, distanceMeters, accuracyMeters } = info;
+
+    if (!isValid) {
+        if (distanceMeters > LOCATION_VALID_RADIUS_METERS && accuracyMeters <= ACCURACY_ACCEPTABLE_METERS) {
+            return 'OUT_OF_RANGE';
+        }
+        if (accuracyMeters > ACCURACY_ACCEPTABLE_METERS) {
+            return 'LOW_ACCURACY';
+        }
+        if (locationStatus === 'SUSPICIOUS') {
+            return 'SUSPICIOUS';
+        }
+        return 'OUT_OF_RANGE';
+    }
+
+    if (locationStatus === 'SUSPICIOUS') {
+        return 'SUCCESS_WITH_WARNING';
+    }
+
+    return 'SUCCESS';
+}
+
+/**
+ * Build full UX object (title, message, canRetry) from a checkin result.
+ */
+export function buildCheckinResultUX(info: CheckinResultInfo): CheckinResultUX {
+    const type = classifyCheckinResult(info);
+
+    switch (type) {
+        case 'OUT_OF_RANGE':
+            return {
+                type,
+                title: '도착 위치 범위 초과',
+                message: `현재 위치가 수업 장소에서 ${Math.round(info.distanceMeters)}m 떨어져 있습니다. 장소에 더 가까이 이동한 후 다시 시도해주세요.`,
+                canRetry: true,
+            };
+
+        case 'LOW_ACCURACY':
+            return {
+                type,
+                title: 'GPS 정확도 낮음',
+                message: `현재 GPS 정확도가 낮습니다 (약 ${Math.round(info.accuracyMeters)}m). 실외로 이동하거나 잠시 기다린 후 다시 시도해주세요.`,
+                canRetry: true,
+            };
+
+        case 'SUSPICIOUS':
+            return {
+                type,
+                title: '위치 확인 불가',
+                message: `위치 정보가 불안정합니다 (${Math.round(info.distanceMeters)}m). 실내에 있는 경우 실외로 이동 후 다시 시도해주세요.`,
+                canRetry: true,
+            };
+
+        case 'SUCCESS_WITH_WARNING':
+            return {
+                type,
+                title: '도착 완료 (참고 안내)',
+                message: `도착이 등록되었습니다. 다만 GPS 신호가 불안정하여 위치가 정확하지 않을 수 있습니다 (${Math.round(info.distanceMeters)}m). 문제가 있을 경우 관리자에게 문의하세요.`,
+                canRetry: false,
+            };
+
+        case 'SUCCESS':
+        default:
+            return {
+                type: 'SUCCESS',
+                title: '완료',
+                message: '정상적으로 처리되었습니다.',
+                canRetry: false,
+            };
+    }
+}
+
+/**
+ * Returns the user-facing accuracy description string.
+ */
+export function describeAccuracy(accuracyMeters: number): string {
+    if (accuracyMeters <= ACCURACY_GOOD_METERS) return '정확도 좋음';
+    if (accuracyMeters <= ACCURACY_ACCEPTABLE_METERS) return '정확도 보통';
+    if (accuracyMeters <= ACCURACY_SUSPICIOUS_METERS) return '정확도 낮음';
+    return '정확도 매우 낮음 (비정상)';
+}
+
+/**
+ * Returns true if the accuracy is low enough to warrant a retry recommendation.
+ */
+export function isLowAccuracy(accuracyMeters: number): boolean {
+    return accuracyMeters > ACCURACY_ACCEPTABLE_METERS;
+}
+
+/**
+ * Returns true if the distance indicates the user is outside the valid radius.
+ */
+export function isOutOfRange(distanceMeters: number): boolean {
+    return distanceMeters > LOCATION_VALID_RADIUS_METERS;
+}
+
+/**
+ * Returns true if the location is suspicious (very far or accuracy extremely poor).
+ */
+export function isSuspicious(distanceMeters: number, accuracyMeters: number): boolean {
+    return distanceMeters > ACCURACY_SUSPICIOUS_METERS || accuracyMeters > ACCURACY_SUSPICIOUS_METERS;
+}
+
+/**
+ * Build the finish-reminder notification UX message.
+ * Called when a push notification for finish-reminder is received.
+ */
+export function buildFinishReminderMessage(lessonTitle: string): string {
+    return `'${lessonTitle}' 강의 종료 처리가 아직 완료되지 않았습니다. 지금 바로 종료 처리를 진행해주세요.`;
+}
+
+/**
+ * Build the finish-reminder notification title.
+ */
+export function buildFinishReminderTitle(): string {
+    return '강의 종료 처리 필요';
+}


### PR DESCRIPTION
## Summary
- New `src/utils/checkinResultUX.ts`: pure functions to classify and render UX for checkin results (OUT_OF_RANGE, LOW_ACCURACY, SUSPICIOUS, SUCCESS_WITH_WARNING, SUCCESS)
- `ScheduleContext`: captures the `ApiAttendanceEvent` response from ARRIVE/FINISH API calls; shows retry Alert with specific message when `canRetry=true`; shows warning alert for `SUCCESS_WITH_WARNING` (suspicious but valid)
- `notificationService`: adds `FINISH_REMINDER` push notification type handler — navigates to home tab for the instructor to complete finish action

Closes #162