### PR TITLE
feat(app-gps): 출발 알림 및 ETA 악화 후속 알림 구현

### DIFF
--- a/__tests__/issue161.test.ts
+++ b/__tests__/issue161.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Tests for issue #161: 출발 알림 및 ETA 악화 후속 알림 구현
+ * Covers: departureAlertService.ts + types.ts + httpClient methods
+ *
+ * 총 35개 이상 테스트 케이스 (정상/예외/사이드이펙트/통합/회귀)
+ */
+
+import {
+  createInitialDepartureAlertState,
+  isAlertableRiskLevel,
+  isHighRiskLevel,
+  isEtaDeteriorated,
+  evaluateDepartureAlerts,
+  evaluateMovementWithoutDeparture,
+  applyFiredAlerts,
+  updateLastEta,
+  buildDepartureAlertMessage,
+  type DepartureAlertState,
+  type DepartureAlertPayload,
+} from '../src/services/departureAlertService';
+
+import type {
+  ApiCommuteRisk,
+  ApiCommuteAlertPolicy,
+  CommuteRiskLevel,
+} from '../src/api/types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const makePolicyEnabled = (): ApiCommuteAlertPolicy => ({
+  bufferMinutes: 15,
+  lateRiskThresholdMinutes: 10,
+  highRiskThresholdMinutes: 5,
+  initialDepartureAlertEnabled: true,
+  etaDeteriorationFollowupEnabled: true,
+  stopAfterDepart: true,
+  movementWithoutDepartureAlertEnabled: true,
+});
+
+const makePolicyAllDisabled = (): ApiCommuteAlertPolicy => ({
+  bufferMinutes: 15,
+  lateRiskThresholdMinutes: 10,
+  highRiskThresholdMinutes: 5,
+  initialDepartureAlertEnabled: false,
+  etaDeteriorationFollowupEnabled: false,
+  stopAfterDepart: false,
+  movementWithoutDepartureAlertEnabled: false,
+});
+
+const makeRisk = (riskLevel: CommuteRiskLevel, etaMinutes = 30): ApiCommuteRisk => ({
+  riskLevel,
+  recommendedAction: '지금 출발하세요',
+  etaMinutes,
+  distanceMeters: 15000,
+  bufferMinutes: 10,
+  riskScore: riskLevel === 'LOW' ? 20 : riskLevel === 'MEDIUM' ? 50 : riskLevel === 'HIGH' ? 75 : 90,
+});
+
+// ─── 1. createInitialDepartureAlertState ─────────────────────────────────────
+
+describe('createInitialDepartureAlertState', () => {
+  test('[정상] 초기 상태는 모든 Set이 비어 있어야 함', () => {
+    const state = createInitialDepartureAlertState();
+    expect(state.initialAlertFired.size).toBe(0);
+    expect(state.etaFollowupFired.size).toBe(0);
+    expect(state.movementWithoutDepartFired.size).toBe(0);
+    expect(Object.keys(state.lastEtaMinutes).length).toBe(0);
+  });
+
+  test('[정상] 두 번 호출해도 독립된 상태를 반환해야 함', () => {
+    const a = createInitialDepartureAlertState();
+    const b = createInitialDepartureAlertState();
+    a.initialAlertFired.add('lesson1');
+    expect(b.initialAlertFired.has('lesson1')).toBe(false);
+  });
+});
+
+// ─── 2. isAlertableRiskLevel ─────────────────────────────────────────────────
+
+describe('isAlertableRiskLevel', () => {
+  test('[정상] LOW는 알림 불필요', () => {
+    expect(isAlertableRiskLevel('LOW')).toBe(false);
+  });
+
+  test('[정상] MEDIUM은 알림 필요', () => {
+    expect(isAlertableRiskLevel('MEDIUM')).toBe(true);
+  });
+
+  test('[정상] HIGH는 알림 필요', () => {
+    expect(isAlertableRiskLevel('HIGH')).toBe(true);
+  });
+
+  test('[정상] VERY_HIGH는 알림 필요', () => {
+    expect(isAlertableRiskLevel('VERY_HIGH')).toBe(true);
+  });
+});
+
+// ─── 3. isHighRiskLevel ───────────────────────────────────────────────────────
+
+describe('isHighRiskLevel', () => {
+  test('[정상] LOW는 높은 위험 아님', () => {
+    expect(isHighRiskLevel('LOW')).toBe(false);
+  });
+
+  test('[정상] MEDIUM은 높은 위험 아님', () => {
+    expect(isHighRiskLevel('MEDIUM')).toBe(false);
+  });
+
+  test('[정상] HIGH는 높은 위험', () => {
+    expect(isHighRiskLevel('HIGH')).toBe(true);
+  });
+
+  test('[정상] VERY_HIGH는 높은 위험', () => {
+    expect(isHighRiskLevel('VERY_HIGH')).toBe(true);
+  });
+});
+
+// ─── 4. isEtaDeteriorated ────────────────────────────────────────────────────
+
+describe('isEtaDeteriorated', () => {
+  test('[정상] ETA가 5분 이상 증가하면 악화', () => {
+    expect(isEtaDeteriorated(30, 35)).toBe(true);
+  });
+
+  test('[정상] ETA가 5분 증가하면 악화 (경계값)', () => {
+    expect(isEtaDeteriorated(30, 35, 5)).toBe(true);
+  });
+
+  test('[정상] ETA가 4분 증가하면 악화 아님', () => {
+    expect(isEtaDeteriorated(30, 34)).toBe(false);
+  });
+
+  test('[정상] ETA가 감소하면 악화 아님', () => {
+    expect(isEtaDeteriorated(30, 25)).toBe(false);
+  });
+
+  test('[정상] ETA가 동일하면 악화 아님', () => {
+    expect(isEtaDeteriorated(30, 30)).toBe(false);
+  });
+
+  test('[정상] 사용자 정의 threshold 사용', () => {
+    expect(isEtaDeteriorated(30, 33, 3)).toBe(true);
+  });
+});
+
+// ─── 5. evaluateDepartureAlerts - 최초 출발 알림 ─────────────────────────────
+
+describe('evaluateDepartureAlerts - 최초 출발 알림', () => {
+  const state = createInitialDepartureAlertState();
+
+  test('[정상] MEDIUM 위험, 미발송 → 최초 알림 반환', () => {
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson1',
+      risk: makeRisk('MEDIUM'),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(true);
+  });
+
+  test('[정상] HIGH 위험, 미발송 → 최초 알림 반환', () => {
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson2',
+      risk: makeRisk('HIGH'),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(true);
+  });
+
+  test('[정상] LOW 위험 → 최초 알림 없음', () => {
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson3',
+      risk: makeRisk('LOW'),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(false);
+  });
+
+  test('[정상] 이미 발송된 경우 최초 알림 없음', () => {
+    const firedState: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson4']),
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson4',
+      risk: makeRisk('HIGH'),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state: firedState,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(false);
+  });
+
+  test('[정상] initialDepartureAlertEnabled=false → 알림 없음', () => {
+    const policy = { ...makePolicyEnabled(), initialDepartureAlertEnabled: false };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson5',
+      risk: makeRisk('HIGH'),
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(false);
+  });
+
+  test('[정상] hasDeparted=true + stopAfterDepart=true → 알림 없음', () => {
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson6',
+      risk: makeRisk('HIGH'),
+      policy: makePolicyEnabled(), // stopAfterDepart=true
+      hasDeparted: true,
+      state,
+    });
+    expect(result.length).toBe(0);
+  });
+
+  test('[정상] hasDeparted=true + stopAfterDepart=false → 알림 발생 가능', () => {
+    const policy = { ...makePolicyEnabled(), stopAfterDepart: false };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson7',
+      risk: makeRisk('HIGH'),
+      policy,
+      hasDeparted: true,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(true);
+  });
+});
+
+// ─── 6. evaluateDepartureAlerts - ETA 악화 후속 알림 ─────────────────────────
+
+describe('evaluateDepartureAlerts - ETA 악화 후속 알림', () => {
+  test('[정상] 최초 알림 발송 후 ETA 악화 → 후속 알림 반환', () => {
+    const state: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson10']),
+      lastEtaMinutes: { lesson10: 30 },
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson10',
+      risk: makeRisk('HIGH', 40), // ETA 30 → 40 (악화)
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(true);
+  });
+
+  test('[정상] ETA 악화 후속 알림 이미 발송 → 재발송 없음', () => {
+    const state: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson11']),
+      etaFollowupFired: new Set(['lesson11']),
+      lastEtaMinutes: { lesson11: 30 },
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson11',
+      risk: makeRisk('HIGH', 45),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(false);
+  });
+
+  test('[정상] ETA 개선되면 후속 알림 없음', () => {
+    const state: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson12']),
+      lastEtaMinutes: { lesson12: 40 },
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson12',
+      risk: makeRisk('HIGH', 35), // ETA 개선
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(false);
+  });
+
+  test('[정상] etaDeteriorationFollowupEnabled=false → 후속 알림 없음', () => {
+    const policy = { ...makePolicyEnabled(), etaDeteriorationFollowupEnabled: false };
+    const state: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson13']),
+      lastEtaMinutes: { lesson13: 30 },
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson13',
+      risk: makeRisk('HIGH', 45),
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(false);
+  });
+
+  test('[정상] lastEtaMinutes 없으면 후속 알림 없음', () => {
+    const state: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      initialAlertFired: new Set(['lesson14']),
+    };
+    const result = evaluateDepartureAlerts({
+      lessonId: 'lesson14',
+      risk: makeRisk('HIGH', 45),
+      policy: makePolicyEnabled(),
+      hasDeparted: false,
+      state,
+    });
+    expect(result.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(false);
+  });
+});
+
+// ─── 7. evaluateMovementWithoutDeparture ─────────────────────────────────────
+
+describe('evaluateMovementWithoutDeparture', () => {
+  const policy = makePolicyEnabled();
+  const state = createInitialDepartureAlertState();
+
+  test('[정상] 이동 중 + 미출발 → 보조 알림 발송', () => {
+    const result = evaluateMovementWithoutDeparture({
+      lessonId: 'lesson20',
+      isMoving: true,
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].alertType).toBe('MOVEMENT_WITHOUT_DEPARTURE');
+  });
+
+  test('[정상] 이동 중이지만 출발 완료 → 알림 없음', () => {
+    const result = evaluateMovementWithoutDeparture({
+      lessonId: 'lesson21',
+      isMoving: true,
+      policy,
+      hasDeparted: true,
+      state,
+    });
+    expect(result.length).toBe(0);
+  });
+
+  test('[정상] 이동 없으면 알림 없음', () => {
+    const result = evaluateMovementWithoutDeparture({
+      lessonId: 'lesson22',
+      isMoving: false,
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    expect(result.length).toBe(0);
+  });
+
+  test('[정상] 이미 발송된 경우 재발송 없음', () => {
+    const firedState: DepartureAlertState = {
+      ...createInitialDepartureAlertState(),
+      movementWithoutDepartFired: new Set(['lesson23']),
+    };
+    const result = evaluateMovementWithoutDeparture({
+      lessonId: 'lesson23',
+      isMoving: true,
+      policy,
+      hasDeparted: false,
+      state: firedState,
+    });
+    expect(result.length).toBe(0);
+  });
+
+  test('[정상] movementWithoutDepartureAlertEnabled=false → 알림 없음', () => {
+    const disabledPolicy = { ...policy, movementWithoutDepartureAlertEnabled: false };
+    const result = evaluateMovementWithoutDeparture({
+      lessonId: 'lesson24',
+      isMoving: true,
+      policy: disabledPolicy,
+      hasDeparted: false,
+      state,
+    });
+    expect(result.length).toBe(0);
+  });
+});
+
+// ─── 8. applyFiredAlerts ─────────────────────────────────────────────────────
+
+describe('applyFiredAlerts', () => {
+  test('[정상] INITIAL_DEPARTURE 발송 시 initialAlertFired에 추가', () => {
+    const state = createInitialDepartureAlertState();
+    const alert: DepartureAlertPayload = {
+      lessonId: 'lessonA',
+      alertType: 'INITIAL_DEPARTURE',
+      etaMinutes: 30,
+    };
+    const next = applyFiredAlerts(state, [alert]);
+    expect(next.initialAlertFired.has('lessonA')).toBe(true);
+    expect(next.lastEtaMinutes['lessonA']).toBe(30);
+  });
+
+  test('[정상] ETA_DETERIORATION_FOLLOWUP 발송 시 etaFollowupFired에 추가', () => {
+    const state = createInitialDepartureAlertState();
+    const alert: DepartureAlertPayload = {
+      lessonId: 'lessonB',
+      alertType: 'ETA_DETERIORATION_FOLLOWUP',
+      etaMinutes: 45,
+    };
+    const next = applyFiredAlerts(state, [alert]);
+    expect(next.etaFollowupFired.has('lessonB')).toBe(true);
+    expect(next.lastEtaMinutes['lessonB']).toBe(45);
+  });
+
+  test('[정상] MOVEMENT_WITHOUT_DEPARTURE 발송 시 movementWithoutDepartFired에 추가', () => {
+    const state = createInitialDepartureAlertState();
+    const alert: DepartureAlertPayload = {
+      lessonId: 'lessonC',
+      alertType: 'MOVEMENT_WITHOUT_DEPARTURE',
+    };
+    const next = applyFiredAlerts(state, [alert]);
+    expect(next.movementWithoutDepartFired.has('lessonC')).toBe(true);
+  });
+
+  test('[사이드이펙트] 원본 상태를 변경하지 않아야 함', () => {
+    const state = createInitialDepartureAlertState();
+    const original = new Set(state.initialAlertFired);
+    applyFiredAlerts(state, [{ lessonId: 'lessonD', alertType: 'INITIAL_DEPARTURE' }]);
+    expect(state.initialAlertFired).toEqual(original);
+  });
+
+  test('[정상] 빈 알림 배열 → 상태 변경 없음', () => {
+    const state = createInitialDepartureAlertState();
+    state.lastEtaMinutes['lessonE'] = 20;
+    const next = applyFiredAlerts(state, []);
+    expect(next.lastEtaMinutes['lessonE']).toBe(20);
+    expect(next.initialAlertFired.size).toBe(0);
+  });
+});
+
+// ─── 9. updateLastEta ────────────────────────────────────────────────────────
+
+describe('updateLastEta', () => {
+  test('[정상] ETA 기록 업데이트', () => {
+    const state = createInitialDepartureAlertState();
+    const next = updateLastEta(state, 'lessonX', 25);
+    expect(next.lastEtaMinutes['lessonX']).toBe(25);
+  });
+
+  test('[사이드이펙트] 원본 상태를 변경하지 않아야 함', () => {
+    const state = createInitialDepartureAlertState();
+    updateLastEta(state, 'lessonY', 30);
+    expect(state.lastEtaMinutes['lessonY']).toBeUndefined();
+  });
+
+  test('[정상] 기존 ETA 덮어쓰기', () => {
+    const state = createInitialDepartureAlertState();
+    state.lastEtaMinutes['lessonZ'] = 20;
+    const next = updateLastEta(state, 'lessonZ', 35);
+    expect(next.lastEtaMinutes['lessonZ']).toBe(35);
+  });
+});
+
+// ─── 10. buildDepartureAlertMessage ──────────────────────────────────────────
+
+describe('buildDepartureAlertMessage', () => {
+  test('[정상] INITIAL_DEPARTURE에 recommendedAction 있으면 그것이 body', () => {
+    const msg = buildDepartureAlertMessage({
+      lessonId: 'l1',
+      alertType: 'INITIAL_DEPARTURE',
+      etaMinutes: 30,
+      recommendedAction: '지금 즉시 출발하세요!',
+    });
+    expect(msg.title).toBe('출발하세요!');
+    expect(msg.body).toBe('지금 즉시 출발하세요!');
+  });
+
+  test('[정상] INITIAL_DEPARTURE에 recommendedAction 없으면 기본 메시지', () => {
+    const msg = buildDepartureAlertMessage({
+      lessonId: 'l2',
+      alertType: 'INITIAL_DEPARTURE',
+      etaMinutes: 20,
+    });
+    expect(msg.body).toContain('20분');
+  });
+
+  test('[정상] ETA_DETERIORATION_FOLLOWUP 메시지 포함 ETA', () => {
+    const msg = buildDepartureAlertMessage({
+      lessonId: 'l3',
+      alertType: 'ETA_DETERIORATION_FOLLOWUP',
+      etaMinutes: 50,
+    });
+    expect(msg.title).toContain('늘어났');
+    expect(msg.body).toContain('50분');
+  });
+
+  test('[정상] MOVEMENT_WITHOUT_DEPARTURE 메시지', () => {
+    const msg = buildDepartureAlertMessage({
+      lessonId: 'l4',
+      alertType: 'MOVEMENT_WITHOUT_DEPARTURE',
+    });
+    expect(msg.title).toContain('출발 체크인');
+    expect(msg.body).toContain('이동이 감지');
+  });
+
+  test('[예외] etaMinutes 없으면 ? 표시', () => {
+    const msg = buildDepartureAlertMessage({
+      lessonId: 'l5',
+      alertType: 'INITIAL_DEPARTURE',
+    });
+    expect(msg.body).toContain('?분');
+  });
+});
+
+// ─── 11. 통합 케이스 ─────────────────────────────────────────────────────────
+
+describe('통합: 전체 알림 사이클', () => {
+  test('[통합] 최초 알림 발송 → 상태 갱신 → ETA 악화 후속 알림 발송', () => {
+    const policy = makePolicyEnabled();
+    let state = createInitialDepartureAlertState();
+    const lessonId = 'integration-1';
+
+    // 1차: 최초 알림
+    const risk1 = makeRisk('HIGH', 30);
+    const alerts1 = evaluateDepartureAlerts({ lessonId, risk: risk1, policy, hasDeparted: false, state });
+    expect(alerts1.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(true);
+    state = applyFiredAlerts(state, alerts1);
+    expect(state.initialAlertFired.has(lessonId)).toBe(true);
+    expect(state.lastEtaMinutes[lessonId]).toBe(30);
+
+    // 2차: ETA 악화 → 후속 알림
+    const risk2 = makeRisk('VERY_HIGH', 40);
+    const alerts2 = evaluateDepartureAlerts({ lessonId, risk: risk2, policy, hasDeparted: false, state });
+    expect(alerts2.some((a) => a.alertType === 'ETA_DETERIORATION_FOLLOWUP')).toBe(true);
+    expect(alerts2.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(false);
+    state = applyFiredAlerts(state, alerts2);
+    expect(state.etaFollowupFired.has(lessonId)).toBe(true);
+
+    // 3차: 동일 악화 반복 → 재발송 없음
+    const risk3 = makeRisk('VERY_HIGH', 55);
+    const alerts3 = evaluateDepartureAlerts({ lessonId, risk: risk3, policy, hasDeparted: false, state });
+    expect(alerts3.length).toBe(0);
+  });
+
+  test('[통합] DEPART 후 stopAfterDepart=true → 이후 알림 없음', () => {
+    const policy = makePolicyEnabled(); // stopAfterDepart=true
+    const state = createInitialDepartureAlertState();
+    const lessonId = 'integration-2';
+
+    const alerts = evaluateDepartureAlerts({
+      lessonId,
+      risk: makeRisk('HIGH', 35),
+      policy,
+      hasDeparted: true,
+      state,
+    });
+    expect(alerts.length).toBe(0);
+  });
+
+  test('[통합] 이동 감지 + 미출발 → 보조 알림 후 재발송 없음', () => {
+    const policy = makePolicyEnabled();
+    let state = createInitialDepartureAlertState();
+    const lessonId = 'integration-3';
+
+    const alerts1 = evaluateMovementWithoutDeparture({ lessonId, isMoving: true, policy, hasDeparted: false, state });
+    expect(alerts1.length).toBe(1);
+    state = applyFiredAlerts(state, alerts1);
+
+    const alerts2 = evaluateMovementWithoutDeparture({ lessonId, isMoving: true, policy, hasDeparted: false, state });
+    expect(alerts2.length).toBe(0);
+  });
+
+  test('[회귀] 모든 정책 비활성 → 어떠한 알림도 없음', () => {
+    const policy = makePolicyAllDisabled();
+    const state = createInitialDepartureAlertState();
+
+    const depAlerts = evaluateDepartureAlerts({
+      lessonId: 'regression-1',
+      risk: makeRisk('VERY_HIGH', 60),
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    const movAlerts = evaluateMovementWithoutDeparture({
+      lessonId: 'regression-1',
+      isMoving: true,
+      policy,
+      hasDeparted: false,
+      state,
+    });
+
+    expect(depAlerts.length).toBe(0);
+    expect(movAlerts.length).toBe(0);
+  });
+
+  test('[회귀] 알림 상태가 다른 lessonId에 영향을 주지 않음 (격리)', () => {
+    const policy = makePolicyEnabled();
+    let state = createInitialDepartureAlertState();
+
+    const alerts = evaluateDepartureAlerts({
+      lessonId: 'isolation-A',
+      risk: makeRisk('HIGH'),
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    state = applyFiredAlerts(state, alerts);
+
+    // isolation-B는 별도 수업 — 영향 없어야 함
+    const alertsB = evaluateDepartureAlerts({
+      lessonId: 'isolation-B',
+      risk: makeRisk('HIGH'),
+      policy,
+      hasDeparted: false,
+      state,
+    });
+    expect(alertsB.some((a) => a.alertType === 'INITIAL_DEPARTURE')).toBe(true);
+  });
+});

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -7,6 +7,8 @@ import {
   ApiChatMessage,
   ApiChatMessageList,
   ApiChatRoom,
+  ApiCommuteAlertPolicy,
+  ApiCommuteRisk,
   ApiCompany,
   ApiContract,
   ApiContractDetail,
@@ -644,5 +646,17 @@ export const httpClient = {
 
   async updateNotificationSettings(body: NotificationSettingsUpdate): Promise<ApiNotificationSettings> {
     return putJson<ApiNotificationSettings>('/me/notification-settings', body);
+  },
+
+  // ---- Commute Risk & Alert Policy API ----
+
+  async getCommuteRisk(lessonId: string, lat: number, lng: number): Promise<ApiCommuteRisk> {
+    return getJson<ApiCommuteRisk>(
+      `/lessons/${encodeURIComponent(lessonId)}/commute-risk?lat=${lat}&lng=${lng}`,
+    );
+  },
+
+  async getCommuteAlertPolicy(): Promise<ApiCommuteAlertPolicy> {
+    return getJson<ApiCommuteAlertPolicy>('/lessons/commute-alert-policy');
   },
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -343,6 +343,29 @@ export interface ApiSignatureAsset {
   updatedAt: string;
 }
 
+// ---- Commute Risk & Alert Policy Types ----
+
+export type CommuteRiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH';
+
+export interface ApiCommuteRisk {
+  riskLevel: CommuteRiskLevel;
+  recommendedAction: string;
+  etaMinutes: number;
+  distanceMeters: number;
+  bufferMinutes: number;
+  riskScore: number;
+}
+
+export interface ApiCommuteAlertPolicy {
+  bufferMinutes: number;
+  lateRiskThresholdMinutes: number;
+  highRiskThresholdMinutes: number;
+  initialDepartureAlertEnabled: boolean;
+  etaDeteriorationFollowupEnabled: boolean;
+  stopAfterDepart: boolean;
+  movementWithoutDepartureAlertEnabled: boolean;
+}
+
 // ---- Document Import API Types ----
 
 export interface ApiDocumentDraft {

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -12,6 +12,16 @@ import {
     type CheckinPhase,
 } from '../services/checkinStateMachine';
 import { evaluateAllLessons, buildNotificationKey, type CurrentPosition } from '../services/gpsNotificationEngine';
+import {
+  createInitialDepartureAlertState,
+  evaluateDepartureAlerts,
+  evaluateMovementWithoutDeparture,
+  applyFiredAlerts,
+  updateLastEta,
+  buildDepartureAlertMessage,
+  type DepartureAlertState,
+} from '../services/departureAlertService';
+import { httpClient } from '../api/httpClient';
 import { queryKeys } from '../query/queryKeys';
 import {
     useAttendanceEventsQuery,
@@ -71,6 +81,7 @@ interface ScheduleContextType {
     submitClassReport: (id: string, text: string) => Promise<void>;
     fetchLessons: () => Promise<void>;
     checkSmartAlerts: (position: CurrentPosition | null) => void;
+    checkDepartureAlerts: (lessonId: string, lat: number, lng: number, hasDeparted: boolean, isMoving?: boolean) => Promise<void>;
     checkinPhases: Record<string, CheckinPhase>;
 
     // Location permission gate
@@ -100,6 +111,7 @@ const ScheduleContext = createContext<ScheduleContextType>({
     submitClassReport: async () => { },
     fetchLessons: async () => { },
     checkSmartAlerts: () => { },
+    checkDepartureAlerts: async () => { },
     checkinPhases: {},
     locationPermission: 'undetermined',
     requestLocationPermission: async () => { },
@@ -176,6 +188,10 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const [firedNotificationKeys, setFiredNotificationKeys] = useState<Set<string>>(new Set());
     // 수업별 체크인 단계 (상태 머신)
     const [localCheckinPhases, setLocalCheckinPhases] = useState<Record<string, CheckinPhase>>({});
+    // 출발 알림 서비스 상태
+    const [departureAlertState, setDepartureAlertState] = useState<DepartureAlertState>(
+      createInitialDepartureAlertState(),
+    );
 
     const classes = useMemo(() => {
         const lessons = lessonsQuery.data ?? [];
@@ -542,6 +558,81 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     };
 
     /**
+     * 출발 알림 서비스 연동:
+     * 주어진 수업에 대해 통근 리스크 API를 조회하고,
+     * 정책에 따라 최초 출발 알림 / ETA 악화 후속 알림을 발송합니다.
+     */
+    const checkDepartureAlerts = async (
+      lessonId: string,
+      lat: number,
+      lng: number,
+      hasDeparted: boolean,
+      isMoving: boolean = false,
+    ): Promise<void> => {
+      try {
+        const [risk, policy] = await Promise.all([
+          httpClient.getCommuteRisk(lessonId, lat, lng),
+          httpClient.getCommuteAlertPolicy(),
+        ]);
+
+        let currentState = departureAlertState;
+        const newNotifications: AppNotification[] = [];
+
+        // 출발 알림 평가
+        const departureAlerts = evaluateDepartureAlerts({
+          lessonId,
+          risk,
+          policy,
+          hasDeparted,
+          state: currentState,
+        });
+
+        for (const alert of departureAlerts) {
+          const msg = buildDepartureAlertMessage(alert);
+          newNotifications.push({
+            id: `departure-${alert.alertType}-${lessonId}-${Date.now()}`,
+            type: alert.alertType,
+            title: msg.title,
+            time: new Date().toISOString(),
+            target: { lessonId, riskLevel: alert.riskLevel, etaMinutes: alert.etaMinutes },
+          });
+        }
+
+        // 출발 미확인 이동 감지 알림 평가
+        const movementAlerts = evaluateMovementWithoutDeparture({
+          lessonId,
+          isMoving,
+          policy,
+          hasDeparted,
+          state: currentState,
+        });
+
+        for (const alert of movementAlerts) {
+          const msg = buildDepartureAlertMessage(alert);
+          newNotifications.push({
+            id: `departure-${alert.alertType}-${lessonId}-${Date.now()}`,
+            type: alert.alertType,
+            title: msg.title,
+            time: new Date().toISOString(),
+            target: { lessonId },
+          });
+        }
+
+        const allFired = [...departureAlerts, ...movementAlerts];
+        if (allFired.length > 0) {
+          currentState = applyFiredAlerts(currentState, allFired);
+          setDepartureAlertState(currentState);
+          setNotifications((prev) => [...prev, ...newNotifications]);
+        } else {
+          // ETA 기록 업데이트 (알림 없어도 추적)
+          setDepartureAlertState((prev) => updateLastEta(prev, lessonId, risk.etaMinutes));
+        }
+      } catch {
+        // 네트워크 오류 등은 조용히 무시 (알림 누락은 허용)
+      }
+    };
+
+    /**
      * GPS 스마트 알림 엔진 연동:
      * 앱 진입/재개 시 현재 위치를 받아 수업별 알림 필요 여부를 평가하고
      * 중복 없이 알림을 추가합니다.
@@ -596,7 +687,7 @@ export const ScheduleProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             classes, addClass, notifications, removeNotification, isProposalResolved, proposalStatus, resolveProposal,
             departedIds, canArriveIds, arrivedIds, canEndClassIds, endedClassIds, readyToReportIds, reportedIds,
             classReports, getClassReport, handleClassAction, submitClassReport, fetchLessons,
-            checkSmartAlerts, checkinPhases,
+            checkSmartAlerts, checkDepartureAlerts, checkinPhases,
             locationPermission, requestLocationPermission, openLocationSettings,
         }}>
             {children}

--- a/src/services/departureAlertService.ts
+++ b/src/services/departureAlertService.ts
@@ -1,0 +1,268 @@
+/**
+ * departureAlertService.ts
+ *
+ * 출발 알림 서비스:
+ * - 최초 출발 알림 노출 (riskLevel 기반, 정책 enabled 체크)
+ * - ETA 악화 시 추가 알림 1회 (etaDeteriorationFollowupEnabled)
+ * - DEPART 이후 출발 알림 중단 (stopAfterDepart)
+ * - 출발 미확인 이동 감지 시 보조 알림 (movementWithoutDepartureAlertEnabled)
+ *
+ * 모든 핵심 함수는 순수 함수로 작성되어 테스트 용이성을 유지합니다.
+ */
+
+import type { ApiCommuteRisk, ApiCommuteAlertPolicy, CommuteRiskLevel } from '../api/types';
+
+// ─── 타입 ─────────────────────────────────────────────────────────────────────
+
+export type DepartureAlertType =
+  | 'INITIAL_DEPARTURE'         // 최초 출발 권고 알림
+  | 'ETA_DETERIORATION_FOLLOWUP' // ETA 악화 후속 알림
+  | 'MOVEMENT_WITHOUT_DEPARTURE'; // 출발 미확인 이동 감지 알림
+
+export interface DepartureAlertState {
+  /** lessonId별 최초 출발 알림 발송 여부 */
+  initialAlertFired: Set<string>;
+  /** lessonId별 ETA 악화 후속 알림 발송 여부 (1회 제한) */
+  etaFollowupFired: Set<string>;
+  /** lessonId별 출발 미확인 이동 감지 알림 발송 여부 */
+  movementWithoutDepartFired: Set<string>;
+  /** lessonId별 마지막으로 기록된 ETA (분) */
+  lastEtaMinutes: Record<string, number>;
+}
+
+export interface DepartureAlertPayload {
+  lessonId: string;
+  alertType: DepartureAlertType;
+  riskLevel?: CommuteRiskLevel;
+  etaMinutes?: number;
+  recommendedAction?: string;
+}
+
+export interface EvaluateDepartureOptions {
+  lessonId: string;
+  risk: ApiCommuteRisk;
+  policy: ApiCommuteAlertPolicy;
+  /** 해당 수업이 이미 DEPART 이벤트를 받았는지 여부 */
+  hasDeparted: boolean;
+  state: DepartureAlertState;
+}
+
+export interface EvaluateMovementOptions {
+  lessonId: string;
+  /** 사용자가 이동 중인지 여부 (속도 또는 위치 변화 기반) */
+  isMoving: boolean;
+  policy: ApiCommuteAlertPolicy;
+  hasDeparted: boolean;
+  state: DepartureAlertState;
+}
+
+// ─── 초기 상태 ────────────────────────────────────────────────────────────────
+
+export function createInitialDepartureAlertState(): DepartureAlertState {
+  return {
+    initialAlertFired: new Set(),
+    etaFollowupFired: new Set(),
+    movementWithoutDepartFired: new Set(),
+    lastEtaMinutes: {},
+  };
+}
+
+// ─── 위험 수준 평가 ────────────────────────────────────────────────────────────
+
+/**
+ * riskLevel이 출발 알림을 트리거해야 하는 수준인지 판단합니다.
+ * MEDIUM 이상이면 true를 반환합니다.
+ */
+export function isAlertableRiskLevel(riskLevel: CommuteRiskLevel): boolean {
+  return riskLevel === 'MEDIUM' || riskLevel === 'HIGH' || riskLevel === 'VERY_HIGH';
+}
+
+/**
+ * riskLevel이 높은 위험 수준인지 판단합니다.
+ * HIGH 이상이면 true를 반환합니다.
+ */
+export function isHighRiskLevel(riskLevel: CommuteRiskLevel): boolean {
+  return riskLevel === 'HIGH' || riskLevel === 'VERY_HIGH';
+}
+
+// ─── ETA 악화 판단 ────────────────────────────────────────────────────────────
+
+/**
+ * 새 ETA가 이전 ETA보다 악화되었는지 판단합니다.
+ * thresholdMinutes 이상 증가했으면 악화로 간주합니다.
+ */
+export function isEtaDeteriorated(
+  prevEtaMinutes: number,
+  newEtaMinutes: number,
+  thresholdMinutes: number = 5,
+): boolean {
+  return newEtaMinutes - prevEtaMinutes >= thresholdMinutes;
+}
+
+// ─── 핵심 평가 함수 ───────────────────────────────────────────────────────────
+
+/**
+ * 현재 위험도/정책 상태를 기반으로 발송해야 할 출발 알림을 평가합니다.
+ *
+ * 규칙:
+ * 1. hasDeparted + stopAfterDepart = true 이면 출발 알림 없음
+ * 2. 최초 알림: initialDepartureAlertEnabled && isAlertableRiskLevel && 미발송
+ * 3. ETA 악화 후속 알림: etaDeteriorationFollowupEnabled && ETA 악화 감지 && 1회 제한
+ *
+ * @returns 발송해야 할 알림 목록 (빈 배열이면 발송 없음)
+ */
+export function evaluateDepartureAlerts(
+  options: EvaluateDepartureOptions,
+): DepartureAlertPayload[] {
+  const { lessonId, risk, policy, hasDeparted, state } = options;
+  const results: DepartureAlertPayload[] = [];
+
+  // DEPART 이후 출발 알림 중단
+  if (hasDeparted && policy.stopAfterDepart) {
+    return results;
+  }
+
+  // 1. 최초 출발 알림
+  if (
+    policy.initialDepartureAlertEnabled &&
+    isAlertableRiskLevel(risk.riskLevel) &&
+    !state.initialAlertFired.has(lessonId)
+  ) {
+    results.push({
+      lessonId,
+      alertType: 'INITIAL_DEPARTURE',
+      riskLevel: risk.riskLevel,
+      etaMinutes: risk.etaMinutes,
+      recommendedAction: risk.recommendedAction,
+    });
+  }
+
+  // 2. ETA 악화 후속 알림 (최초 알림이 이미 발송됐거나 현재 발송 예정인 경우에만 유효)
+  const initialAlreadyFired = state.initialAlertFired.has(lessonId);
+  const initialWillFire = results.some((r) => r.alertType === 'INITIAL_DEPARTURE');
+  const hasInitialContext = initialAlreadyFired || initialWillFire;
+
+  if (
+    hasInitialContext &&
+    policy.etaDeteriorationFollowupEnabled &&
+    !state.etaFollowupFired.has(lessonId)
+  ) {
+    const prevEta = state.lastEtaMinutes[lessonId];
+    if (prevEta !== undefined && isEtaDeteriorated(prevEta, risk.etaMinutes)) {
+      results.push({
+        lessonId,
+        alertType: 'ETA_DETERIORATION_FOLLOWUP',
+        riskLevel: risk.riskLevel,
+        etaMinutes: risk.etaMinutes,
+        recommendedAction: risk.recommendedAction,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * 출발 미확인 이동 감지 알림을 평가합니다.
+ *
+ * 규칙:
+ * - movementWithoutDepartureAlertEnabled && isMoving && !hasDeparted && 미발송
+ *
+ * @returns 발송해야 할 알림 목록 (빈 배열이면 발송 없음)
+ */
+export function evaluateMovementWithoutDeparture(
+  options: EvaluateMovementOptions,
+): DepartureAlertPayload[] {
+  const { lessonId, isMoving, policy, hasDeparted, state } = options;
+
+  if (
+    policy.movementWithoutDepartureAlertEnabled &&
+    isMoving &&
+    !hasDeparted &&
+    !state.movementWithoutDepartFired.has(lessonId)
+  ) {
+    return [{ lessonId, alertType: 'MOVEMENT_WITHOUT_DEPARTURE' }];
+  }
+
+  return [];
+}
+
+// ─── 상태 업데이트 헬퍼 ────────────────────────────────────────────────────────
+
+/**
+ * 발송 완료된 알림들을 상태에 반영하여 새 상태를 반환합니다.
+ * 원본 상태를 변경하지 않고 새 Set/Record를 생성합니다.
+ */
+export function applyFiredAlerts(
+  state: DepartureAlertState,
+  fired: DepartureAlertPayload[],
+): DepartureAlertState {
+  const initialAlertFired = new Set(state.initialAlertFired);
+  const etaFollowupFired = new Set(state.etaFollowupFired);
+  const movementWithoutDepartFired = new Set(state.movementWithoutDepartFired);
+  const lastEtaMinutes = { ...state.lastEtaMinutes };
+
+  for (const alert of fired) {
+    if (alert.alertType === 'INITIAL_DEPARTURE') {
+      initialAlertFired.add(alert.lessonId);
+      if (alert.etaMinutes !== undefined) {
+        lastEtaMinutes[alert.lessonId] = alert.etaMinutes;
+      }
+    } else if (alert.alertType === 'ETA_DETERIORATION_FOLLOWUP') {
+      etaFollowupFired.add(alert.lessonId);
+      if (alert.etaMinutes !== undefined) {
+        lastEtaMinutes[alert.lessonId] = alert.etaMinutes;
+      }
+    } else if (alert.alertType === 'MOVEMENT_WITHOUT_DEPARTURE') {
+      movementWithoutDepartFired.add(alert.lessonId);
+    }
+  }
+
+  return { initialAlertFired, etaFollowupFired, movementWithoutDepartFired, lastEtaMinutes };
+}
+
+/**
+ * ETA 기록만 업데이트합니다 (알림 발송 없이 ETA를 추적할 때 사용).
+ */
+export function updateLastEta(
+  state: DepartureAlertState,
+  lessonId: string,
+  etaMinutes: number,
+): DepartureAlertState {
+  return {
+    ...state,
+    lastEtaMinutes: { ...state.lastEtaMinutes, [lessonId]: etaMinutes },
+  };
+}
+
+// ─── 알림 메시지 빌더 ─────────────────────────────────────────────────────────
+
+/**
+ * 알림 타입과 위험 정보로 사용자에게 표시할 제목/내용을 생성합니다.
+ */
+export function buildDepartureAlertMessage(alert: DepartureAlertPayload): {
+  title: string;
+  body: string;
+} {
+  switch (alert.alertType) {
+    case 'INITIAL_DEPARTURE':
+      return {
+        title: '출발하세요!',
+        body: alert.recommendedAction
+          ? alert.recommendedAction
+          : `예상 도착 ${alert.etaMinutes ?? '?'}분 — 지금 출발하세요.`,
+      };
+    case 'ETA_DETERIORATION_FOLLOWUP':
+      return {
+        title: '도착 시간이 늘어났습니다',
+        body: `현재 예상 도착까지 ${alert.etaMinutes ?? '?'}분이 필요합니다. 서둘러 출발하세요.`,
+      };
+    case 'MOVEMENT_WITHOUT_DEPARTURE':
+      return {
+        title: '출발 체크인을 잊으셨나요?',
+        body: '이동이 감지되었지만 출발 체크인이 등록되지 않았습니다. 출발을 등록해주세요.',
+      };
+    default:
+      return { title: '출발 알림', body: '' };
+  }
+}


### PR DESCRIPTION
Closes #161

## Summary
- `ApiCommuteRisk`, `ApiCommuteAlertPolicy` 타입 추가 (`src/api/types.ts`)
- `httpClient.getCommuteRisk()`, `httpClient.getCommuteAlertPolicy()` 메서드 추가
- `departureAlertService.ts` 신규 생성: 출발 알림 로직 순수 함수로 구현
- `ScheduleContext.tsx`에 `checkDepartureAlerts` 연동

## Test plan
- [ ] `npx jest __tests__/issue161.test.ts --no-coverage` → 51개 전체 통과 확인
- [ ] 최초 출발 알림: MEDIUM 이상 위험 시 발송, LOW 시 미발송
- [ ] ETA 악화 후속 알림: 5분 이상 증가 시 1회 발송
- [ ] DEPART 이후 stopAfterDepart=true 시 알림 중단
- [ ] 출발 미확인 이동 감지 알림 (1회 제한)
- [ ] 정책 비활성 시 알림 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)