### PR TITLE
fix(app): 뒤로가기 버튼 텍스트 제거 통일

### DIFF
--- a/__tests__/issue192.test.ts
+++ b/__tests__/issue192.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Issue #192 — 뒤로가기 버튼 텍스트 제거 통일
+ *
+ * 실제 레이아웃 파일 및 화면 파일을 직접 읽어
+ * headerBackTitleVisible: false 적용 및 이전 해킹 제거를 검증한다.
+ * 소스가 원래대로 되돌아가면 테스트가 실패하여 회귀를 방지한다.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+
+const rootLayoutSrc = fs.readFileSync(path.join(ROOT, 'app', '_layout.tsx'), 'utf-8');
+const docsLayoutSrc = fs.readFileSync(path.join(ROOT, 'app', '(tabs)', 'docs', '_layout.tsx'), 'utf-8');
+const profileLayoutSrc = fs.readFileSync(path.join(ROOT, 'app', '(tabs)', 'profile', '_layout.tsx'), 'utf-8');
+const appSettingsSrc = fs.readFileSync(path.join(ROOT, 'src', 'screens', 'AppSettingsScreen.tsx'), 'utf-8');
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 1. 정상 케이스 — 루트 Stack에 headerBackTitleVisible: false 적용 확인
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('[정상] app/_layout.tsx — 루트 Stack 뒤로가기 텍스트 숨김', () => {
+  test('T01 — screenOptions에 headerBackTitleVisible: false 포함', () => {
+    expect(rootLayoutSrc).toContain('headerBackTitleVisible: false');
+  });
+
+  test('T02 — Stack screenOptions 속성으로 선언됨', () => {
+    expect(rootLayoutSrc).toMatch(/Stack\s+screenOptions=\{\{[^}]*headerBackTitleVisible:\s*false/s);
+  });
+
+  test('T03 — (tabs) Screen은 headerShown: false 유지', () => {
+    expect(rootLayoutSrc).toContain('name="(tabs)" options={{ headerShown: false }}');
+  });
+
+  test('T04 — profile/instructor 화면 title 유지', () => {
+    expect(rootLayoutSrc).toContain("name=\"profile/instructor\"");
+    expect(rootLayoutSrc).toContain("title: '강사 프로필 설정'");
+  });
+
+  test('T05 — profile/settings 화면 title 유지', () => {
+    expect(rootLayoutSrc).toContain("name=\"profile/settings\"");
+  });
+
+  test('T06 — settings 화면 title 유지', () => {
+    expect(rootLayoutSrc).toContain("name=\"settings\"");
+    expect(rootLayoutSrc).toContain("title: '앱 설정'");
+  });
+
+  test('T07 — profile/signature 화면 등록 유지', () => {
+    expect(rootLayoutSrc).toContain("name=\"profile/signature\"");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2. 정상 케이스 — docs _layout에도 headerBackTitleVisible: false 적용
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('[정상] app/(tabs)/docs/_layout.tsx — 뒤로가기 텍스트 숨김', () => {
+  test('T08 — screenOptions에 headerBackTitleVisible: false 포함', () => {
+    expect(docsLayoutSrc).toContain('headerBackTitleVisible: false');
+  });
+
+  test('T09 — headerShown: true 유지 (서브 스크린은 헤더 표시)', () => {
+    expect(docsLayoutSrc).toContain('headerShown: true');
+  });
+
+  test('T10 — sign 화면 title 유지', () => {
+    expect(docsLayoutSrc).toContain("name=\"sign\"");
+    expect(docsLayoutSrc).toContain("title: '서명 상세'");
+  });
+
+  test('T11 — contract 화면 title 유지', () => {
+    expect(docsLayoutSrc).toContain("name=\"contract\"");
+    expect(docsLayoutSrc).toContain("title: '계약서 상세'");
+  });
+
+  test('T12 — request 화면 title 유지', () => {
+    expect(docsLayoutSrc).toContain("name=\"request\"");
+    expect(docsLayoutSrc).toContain("title: '요청 상세'");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 3. 예외 케이스 — 이전 해킹 방식(headerBackTitle: ' ') 제거 확인
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('[예외] AppSettingsScreen — headerBackTitle 해킹 제거', () => {
+  test('T13 — headerBackTitle: \'  \' 해킹 제거됨', () => {
+    expect(appSettingsSrc).not.toContain("headerBackTitle:");
+  });
+
+  test('T14 — headerLeft 커스텀 버튼은 유지', () => {
+    expect(appSettingsSrc).toContain('headerLeft:');
+  });
+
+  test('T15 — navigation.setOptions 호출 유지', () => {
+    expect(appSettingsSrc).toContain('navigation.setOptions(');
+  });
+
+  test('T16 — ChevronLeft 아이콘 사용 유지', () => {
+    expect(appSettingsSrc).toContain('ChevronLeft');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 4. 사이드 이펙트 — profile _layout은 headerShown: false 유지 확인
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('[사이드이펙트] app/(tabs)/profile/_layout.tsx — 기존 설정 미영향', () => {
+  test('T17 — profile layout은 headerShown: false 유지', () => {
+    expect(profileLayoutSrc).toContain('headerShown: false');
+  });
+
+  test('T18 — profile/index Screen 등록 유지', () => {
+    expect(profileLayoutSrc).toContain('name="index"');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 5. 통합 케이스 — 루트 레이아웃 구조 무결성
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('[통합] 레이아웃 파일 구조 무결성', () => {
+  test('T19 — 루트 _layout에 Stack import 존재', () => {
+    expect(rootLayoutSrc).toContain("from 'expo-router'");
+    expect(rootLayoutSrc).toContain('Stack');
+  });
+
+  test('T20 — 루트 _layout에 ThemeProvider 유지', () => {
+    expect(rootLayoutSrc).toContain('ThemeProvider');
+  });
+});

--- a/app/(tabs)/docs/_layout.tsx
+++ b/app/(tabs)/docs/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router';
 
 export default function DocsLayout() {
   return (
-    <Stack screenOptions={{ headerShown: true }}>
+    <Stack screenOptions={{ headerShown: true, headerBackTitleVisible: false }}>
       <Stack.Screen name="index" options={{ title: '서류 / 계약', headerShown: false, headerShadowVisible: false }} />
       <Stack.Screen name="sign" options={{ title: '서명 상세' }} />
       <Stack.Screen name="contract" options={{ title: '계약서 상세' }} />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -132,7 +132,7 @@ export default function RootLayout() {
 
   const stack = (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
+      <Stack screenOptions={{ headerBackTitleVisible: false }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="docs/import" options={{ headerShown: false }} />
         <Stack.Screen name="docs/review" options={{ headerShown: false }} />

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -44,7 +44,6 @@ export default function AppSettingsScreen() {
 
     useEffect(() => {
         navigation.setOptions({
-            headerBackTitle: ' ',
             headerLeft: () => (
                 <TouchableOpacity
                     onPress={() => router.back()}


### PR DESCRIPTION
## Summary
- 루트 `Stack`에 `screenOptions={{ headerBackTitleVisible: false }}` 전역 적용으로 모든 화면 뒤로가기 버튼 텍스트 일괄 숨김
- `app/(tabs)/docs/_layout.tsx`에도 동일 옵션 추가
- `AppSettingsScreen`의 `headerBackTitle: ' '` 임시 해킹 제거 (전역 설정으로 통합)

## Test plan
- [x] `__tests__/issue192.test.ts` 20개 테스트 전체 통과
- [x] 루트 Stack screenOptions에 headerBackTitleVisible: false 적용 확인
- [x] docs 서브 Stack에 동일 옵션 적용 확인
- [x] 기존 화면 title/options 미영향 확인
- [x] AppSettingsScreen headerBackTitle 해킹 제거 확인

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)