### PR TITLE
fix: push notification type normalize 매핑 및 거절 사유 필수 검증 (#217)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ __tests__/
 
 .claude
 PERFORMANCE_REPORT.md
+CLAUDE.md
+freeb-b6c6d-firebase-adminsdk-fbsvc-6ed05102a5.json
+google-services.json
+.gitignore

--- a/src/screens/DocLessonRequestDetailScreen.tsx
+++ b/src/screens/DocLessonRequestDetailScreen.tsx
@@ -81,11 +81,18 @@ export default function DocLessonRequestDetailScreen() {
 
   const handleRespond = async (action: 'ACCEPT' | 'REJECT') => {
     if (!request || submitting) return;
+
+    const trimmedReason = rejectReason.trim();
+    if (action === 'REJECT' && !trimmedReason) {
+      Alert.alert('거절 사유 필요', '거절 사유를 입력해주세요.');
+      return;
+    }
+
     try {
       await respondToRequestMutation.mutateAsync({
         requestId: request.requestId,
         action,
-        rejectionReason: action === 'REJECT' ? rejectReason.trim() || undefined : undefined,
+        rejectionReason: action === 'REJECT' ? trimmedReason : undefined,
       });
       setRejectMode(false);
       setRejectReason('');

--- a/src/screens/DocsScreen.tsx
+++ b/src/screens/DocsScreen.tsx
@@ -131,11 +131,18 @@ export default function DocsScreen() {
 
     const handleRespond = async (requestId: string, action: 'ACCEPT' | 'REJECT', reason?: string) => {
         if (respondToRequestMutation.isPending) return;
+
+        const trimmedReason = reason?.trim() ?? '';
+        if (action === 'REJECT' && !trimmedReason) {
+            Alert.alert('거절 사유 필요', '거절 사유를 입력해주세요.');
+            return;
+        }
+
         try {
             await respondToRequestMutation.mutateAsync({
                 requestId,
                 action,
-                rejectionReason: reason?.trim() || undefined,
+                rejectionReason: action === 'REJECT' ? trimmedReason : undefined,
             });
 
             if (action === 'ACCEPT') {

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -61,6 +61,51 @@ const DEFAULT_SETTINGS: ApiNotificationSettings = {
 
 // ─── 내부 유틸 ────────────────────────────────────────────────────────────────
 
+/**
+ * backend에서 전달하는 data.type 문자열을 앱에서 사용하는 canonical 타입으로 매핑합니다.
+ *
+ * backend 예시:
+ * - lesson_request_created
+ * - contract_sent
+ * - settlement_paid
+ * - lesson_finish_reminder
+ * - smart_departure_alert
+ *
+ * app canonical 타입:
+ * - LESSON_REQUEST
+ * - CONTRACT_SENT
+ * - SETTLEMENT
+ * - FINISH_REMINDER
+ * - GPS_DEPARTURE
+ */
+function normalizeNotificationType(rawType?: string): string | undefined {
+    if (!rawType) return undefined;
+
+    const map: Record<string, string> = {
+        // Lesson request
+        LESSON_REQUEST: 'LESSON_REQUEST',
+        lesson_request_created: 'LESSON_REQUEST',
+
+        // Contract
+        CONTRACT_SENT: 'CONTRACT_SENT',
+        contract_sent: 'CONTRACT_SENT',
+
+        // Settlement
+        SETTLEMENT: 'SETTLEMENT',
+        settlement_paid: 'SETTLEMENT',
+
+        // Finish reminder
+        FINISH_REMINDER: 'FINISH_REMINDER',
+        lesson_finish_reminder: 'FINISH_REMINDER',
+
+        // Smart departure / GPS alerts
+        GPS_DEPARTURE: 'GPS_DEPARTURE',
+        smart_departure_alert: 'GPS_DEPARTURE',
+    };
+
+    return map[rawType] ?? rawType;
+}
+
 function isApiUnavailableError(e: unknown): boolean {
     const err = e as ApiError | undefined;
     return err?.status === 404 || err?.status === 501;
@@ -130,13 +175,15 @@ export function setupNotificationHandlers(): () => void {
             return;
         }
 
-        if (data?.type === 'LESSON_REQUEST') {
+        const normalizedType = normalizeNotificationType(data?.type);
+
+        if (normalizedType === 'LESSON_REQUEST') {
             router.replace({ pathname: '/(tabs)/docs', params: { targetTab: '제안' } } as any);
-        } else if (data?.type === 'CONTRACT_SENT') {
+        } else if (normalizedType === 'CONTRACT_SENT') {
             router.replace({ pathname: '/(tabs)/docs', params: { targetTab: '계약' } } as any);
-        } else if (data?.type === 'SETTLEMENT') {
+        } else if (normalizedType === 'SETTLEMENT') {
             router.replace('/(tabs)/income' as any);
-        } else if (data?.type === 'FINISH_REMINDER') {
+        } else if (normalizedType === 'FINISH_REMINDER') {
             // Navigate to home tab where the user can tap FINISH on the relevant lesson
             router.replace('/(tabs)/' as any);
         }


### PR DESCRIPTION
## 변경 사항

### notificationService.ts
- \
ormalizeNotificationType()\ 추가: backend snake_case → app canonical 타입 매핑
- 탭 라우팅 분기에 normalize 적용

### DocsScreen / DocLessonRequestDetailScreen
- REJECT 시 거절 사유 미입력 → Alert 표시 후 return

### .gitignore
- 민감 파일 목록 추가

Closes #217