### PR TITLE
fix(#224): IncomeScreen 정산 목록 key prop 중복 경고 수정

### DIFF
--- a/src/screens/IncomeScreen.tsx
+++ b/src/screens/IncomeScreen.tsx
@@ -281,7 +281,7 @@ export default function IncomeScreen() {
                 {!isLoading &&
                     filteredSettlements.map((item) => (
                         <TouchableOpacity
-                            key={item.settlementId}
+                            key={item.settlementId ?? `${item.lessonId}-${item.month}`}
                             style={styles.historyItem}
                             onPress={() => setSelectedDetail(item)}
                         >


### PR DESCRIPTION
## Summary
- `filteredSettlements.map()`의 `key={item.settlementId}` → `key={item.settlementId ?? \`${item.lessonId}-${item.month}\`}`
- `settlementId`가 `undefined`일 때 `lessonId-month` 조합으로 폴백해 항상 유니크 key 보장

## Test plan
- [ ] 실기기에서 정산 목록 렌더링 시 key prop 경고 미발생 확인

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)