### PR TITLE
fix(#226): 정산 상세 모달 닫기 버튼 Safe Area 및 Floating 스타일 적용

### DIFF
--- a/src/screens/IncomeScreen.tsx
+++ b/src/screens/IncomeScreen.tsx
@@ -376,7 +376,7 @@ export default function IncomeScreen() {
                 onRequestClose={() => setSelectedDetail(null)}
             >
                 <View style={styles.modalOverlay}>
-                    <View style={styles.modalContent}>
+                    <View style={[styles.modalContent, { paddingBottom: insets.bottom + 16 }]}>
                         <View style={styles.modalHeader}>
                             <Text style={styles.modalTitle}>
                                 {selectedDetail ? formatMonth(selectedDetail.month) : ''} 정산 상세 내역
@@ -426,7 +426,12 @@ export default function IncomeScreen() {
                             title="닫기"
                             variant="primary"
                             onPress={() => setSelectedDetail(null)}
-                            style={{ paddingVertical: 15 }}
+                            style={{
+                                marginHorizontal: 16,
+                                paddingVertical: 15,
+                                borderRadius: 14,
+                                justifyContent: 'center',
+                            }}
                         />
                     </View>
                 </View>


### PR DESCRIPTION
## Summary
- 모달 `paddingBottom`을 `insets.bottom + 16`으로 변경 → Home Indicator 겹침 해소
- 닫기 버튼 `marginHorizontal: 16`, `borderRadius: 14` → Floating 스타일
- `justifyContent: 'center'` → 텍스트 수직 중앙 정렬

## Test plan
- [ ] iPhone(Home Indicator 있는 기기)에서 닫기 버튼이 안전 영역 위에 위치하는지 확인
- [ ] Android에서 버튼 위치 정상 확인

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)